### PR TITLE
Fix: Add error handling for Gitleaks download failure

### DIFF
--- a/workshop/secrets_scan/gitleaks/workflow.yml
+++ b/workshop/secrets_scan/gitleaks/workflow.yml
@@ -29,7 +29,7 @@ jobs:
         id: scan-tool
         run: |
           # Install Gitleaks
-          wget -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
+          wget -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz || { echo "❌ Failed to download Gitleaks"; exit 1; }
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp/
           sudo mv /tmp/gitleaks /usr/local/bin/
 


### PR DESCRIPTION
## Summary

This PR adds error handling for the wget command that downloads Gitleaks in the secrets scan workflow.

## Problem

The original wget command had no error handling. If the download failed due to:
- Network issues
- 404 errors (version no longer available)
- Server errors

The subsequent `tar` and `mv` commands would fail with cryptic errors, and the workflow wouldn't properly report the installation failure.

## Solution

Added error handling using the `||` operator to catch wget failures and exit with a clear error message:

```bash
wget -O /tmp/gitleaks.tar.gz ... || { echo "❌ Failed to download Gitleaks"; exit 1; }
```

## Testing

The workflow will now properly fail with a clear error message if the Gitleaks download fails, making debugging easier.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.