### PR TITLE
Workshop fixes from a first-time-attendee dry-run

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -17,17 +17,17 @@ on:
         value: ${{ jobs.dast.outputs.result }}
 
 jobs:
-  # 🚧 REPLACE THIS ENTIRE 'jobs:' SECTION WITH WORKSHOP CONTENT! 🚧
-  # Copy from: workshop/dast/{tool}/workflow.yml
+  # 🚧 NOT YET — DAST module is planned but not part of v1 of the workshop.
+  # The workshop/dast/ folder will be added in a future release.
   dast:
-    name: "🚧 DAST - Workshop Placeholder"
+    name: "🚧 DAST - Coming soon"
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.placeholder.outputs.result }}
     steps:
-      - name: Workshop Placeholder
+      - name: DAST module not yet shipped
         id: placeholder
         run: |
-          echo "🚧 Replace this job with content from workshop/dast/{tool}/workflow.yml!"
-          echo "This will implement: DAST security testing with your chosen tool"
-          echo "result=workshop-placeholder" >> "$GITHUB_OUTPUT"
+          echo "🚧 DAST is planned for a future workshop iteration."
+          echo "    For now, this job is a no-op placeholder so the orchestrator stays green."
+          echo "result=not-yet-shipped" >> "$GITHUB_OUTPUT"

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -9,17 +9,290 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.17.15"
+        "axios": "1.6.0"
       },
       "devDependencies": {},
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     }
   }

--- a/code/package.json
+++ b/code/package.json
@@ -9,7 +9,7 @@
     "test": "echo 'No tests configured'"
   },
   "dependencies": {
-    "lodash": "4.17.15"
+    "axios": "1.6.0"
   },
   "devDependencies": {},
   "engines": {

--- a/code/src/simple-app.js
+++ b/code/src/simple-app.js
@@ -81,34 +81,27 @@ const server = http.createServer((req, res) => {
     `);
   } else if (url === '/fetch' && method === 'POST') {
     let body = '';
-    req.on('data', chunk => {
-      body += chunk.toString();
-    });
-    req.on('end', () => {
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      let targetUrl;
       try {
-        const data = JSON.parse(body);
-        const targetUrl = data.url;
-        if (!targetUrl) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'No url provided' }));
-          return;
-        }
-        // TODO: validate URL allow-list before fetching to prevent SSRF
-        axios.get(targetUrl)
-          .then(response => {
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({
-              status: response.status,
-              data: response.data
-            }));
-          })
-          .catch(err => {
-            res.writeHead(502, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ error: err.message }));
-          });
-      } catch (e) {
+        ({ url: targetUrl } = JSON.parse(body));
+      } catch {
         res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        return res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+      if (!targetUrl) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'No url provided' }));
+      }
+      try {
+        // TODO: validate URL allow-list before fetching to prevent SSRF
+        const { status, data } = await axios.get(targetUrl);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status, data }));
+      } catch (err) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
       }
     });
   } else if (url === '/data' && method === 'GET') {

--- a/code/src/simple-app.js
+++ b/code/src/simple-app.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const axios = require('axios');
 
 const AWS_ACCESS_KEY_ID = 'AKIA2T2SJH6MS337PDWL'
 const AWS_SECRET_ACCESS_KEY = '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'
@@ -78,6 +79,38 @@ const server = http.createServer((req, res) => {
       </body>
       </html>
     `);
+  } else if (url === '/fetch' && method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const targetUrl = data.url;
+        if (!targetUrl) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'No url provided' }));
+          return;
+        }
+        // TODO: validate URL allow-list before fetching to prevent SSRF
+        axios.get(targetUrl)
+          .then(response => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              status: response.status,
+              data: response.data
+            }));
+          })
+          .catch(err => {
+            res.writeHead(502, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: err.message }));
+          });
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
   } else if (url === '/data' && method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({

--- a/workshop/code_scan/README.md
+++ b/workshop/code_scan/README.md
@@ -34,14 +34,24 @@ Malicious actors can exploit vulnerabilities in your code to gain unauthorized a
 
 ## Tools Used in This Module
 
+### SAST tools
+
 - [**CodeQL**](https://github.com/github/codeql) - GitHub's semantic code analysis engine for deep security analysis
   - [GitHub Action](https://github.com/github/codeql-action) | [Documentation](https://codeql.github.com/docs/)
-- [**Semgrep**](https://github.com/semgrep/semgrep) - Fast pattern-based security scanner with extensive rule sets 
+- [**Semgrep**](https://github.com/semgrep/semgrep) - Fast pattern-based security scanner with extensive rule sets
   - [Documentation](https://semgrep.dev/docs/) | [Community Rules](https://semgrep.dev/explore)
-- [**Dependency Check**](https://github.com/dependency-check/DependencyCheck) - OWASP tool for Software Composition Analysis (SCA) to identify known vulnerabilities in dependencies
-  - [GitHub Action](https://github.com/dependency-check/Dependency-Check_Action) | [Documentation](https://jeremylong.github.io/DependencyCheck/)
 
 > **Note**: Different ecosystems have specialized SAST tools (e.g., ESLint with security plugins for JavaScript, Bandit for Python, Brakeman for Ruby on Rails) that can provide more targeted analysis alongside general-purpose scanners.
+
+### SCA tools
+
+These two SCA tools pull vulnerability data from different sources, so the same dependency may surface (or not) depending on the choice. Worth knowing both:
+
+- [**osv-scanner**](https://github.com/google/osv-scanner) - Modern, lockfile-based scanner from Google. Queries [OSV.dev](https://osv.dev/), an open-standard database that aggregates GitHub Advisories, RustSec, PyPA, GoVulnDB and others. No external setup, no API keys, no DB downloads.
+  - [GitHub Action](https://github.com/google/osv-scanner-action) | [Documentation](https://google.github.io/osv-scanner/)
+- [**OWASP Dependency Check**](https://github.com/dependency-check/DependencyCheck) - Long-running OWASP project, focused on identifying known vulnerabilities in declared dependencies. Sources its data from NVD directly.
+  - [GitHub Action](https://github.com/dependency-check/Dependency-Check_Action) | [Documentation](https://jeremylong.github.io/DependencyCheck/)
+  - **Heads up**: since 2024 NVD aggressively rate-limits unauthenticated clients, so without an `NVD_API_KEY` ([request one here](https://nvd.nist.gov/developers/request-an-api-key)) Dependency Check effectively returns 0 findings — a silent false-pass that defeats the point of running it. If you don't want to manage an external key, prefer osv-scanner above.
 
 ## Learning Objectives
 

--- a/workshop/code_scan/README.md
+++ b/workshop/code_scan/README.md
@@ -45,13 +45,11 @@ Malicious actors can exploit vulnerabilities in your code to gain unauthorized a
 
 ### SCA tools
 
-These two SCA tools pull vulnerability data from different sources, so the same dependency may surface (or not) depending on the choice. Worth knowing both:
-
-- [**osv-scanner**](https://github.com/google/osv-scanner) - Modern, lockfile-based scanner from Google. Queries [OSV.dev](https://osv.dev/), an open-standard database that aggregates GitHub Advisories, RustSec, PyPA, GoVulnDB and others. No external setup, no API keys, no DB downloads.
+- [**osv-scanner**](https://github.com/google/osv-scanner) - Lockfile-based vulnerability scanner backed by the [OSV.dev](https://osv.dev/) database
   - [GitHub Action](https://github.com/google/osv-scanner-action) | [Documentation](https://google.github.io/osv-scanner/)
-- [**OWASP Dependency Check**](https://github.com/dependency-check/DependencyCheck) - Long-running OWASP project, focused on identifying known vulnerabilities in declared dependencies. Sources its data from NVD directly.
+- [**OWASP Dependency Check**](https://github.com/dependency-check/DependencyCheck) - OWASP tool for Software Composition Analysis (SCA) to identify known vulnerabilities in dependencies
   - [GitHub Action](https://github.com/dependency-check/Dependency-Check_Action) | [Documentation](https://jeremylong.github.io/DependencyCheck/)
-  - **Heads up**: since 2024 NVD aggressively rate-limits unauthenticated clients, so without an `NVD_API_KEY` ([request one here](https://nvd.nist.gov/developers/request-an-api-key)) Dependency Check effectively returns 0 findings — a silent false-pass that defeats the point of running it. If you don't want to manage an external key, prefer osv-scanner above.
+  - **Heads up**: Dependency Check requires an `NVD_API_KEY` to keep its CVE database up to date — see [NVD developers](https://nvd.nist.gov/developers/request-an-api-key). Without one, the scan may return 0 findings.
 
 ## Learning Objectives
 

--- a/workshop/code_scan/sast/codeQL/workflow.yml
+++ b/workshop/code_scan/sast/codeQL/workflow.yml
@@ -5,26 +5,11 @@
 # CodeQL is a static analysis tool for finding security vulnerabilities in code
 # Repository: https://github.com/github/codeql
 #
-# In this workshop CodeQL focuses on data-flow / taint vulnerabilities — its
-# sweet spot. Hardcoded secrets are NOT its job, that lives in the
-# secrets_scan module. Expect this scan to surface the command-line
-# injection at code/src/simple-app.js:41 (user-controlled `filePath` passed
-# to `child_process.exec`).
-#
-# Why we drive the analysis manually instead of using
-# `github/codeql-action/analyze`: when triggered on `pull_request`, the
-# action filters the SARIF to only include alerts the PR introduces
-# relative to the base branch. For a workshop PR that doesn't touch
-# simple-app.js, every "pre-existing" finding gets stripped — silent green.
-# Running `codeql database analyze` directly with the CLI bypasses that
-# filter and reports the full set of findings.
-#
 # TO USE THIS JOB:
 # 1. Copy this entire job definition into .github/workflows/code-scan.yml
 # 2. Replace the current jobs: definition with this one
-# 3. The job builds a CodeQL DB from the repo, runs the security-extended
-#    suite, and counts findings from the resulting SARIF.
-# 4. The scan will fail if any data-flow vulnerabilities are found.
+# 3. The job will automatically scan all code in the code/ directory
+# 4. The scan will fail if vulnerabilities are found
 # =============================================================================
 
 jobs:
@@ -46,17 +31,8 @@ jobs:
         with:
           languages: javascript
 
-      - name: Locate codeql binary
-        run: |
-          # The init action extracts the toolchain into the runner's tool cache
-          # but doesn't put it on PATH. Find the binary and append its dir.
-          CODEQL_BIN=$(find "$RUNNER_TOOL_CACHE/CodeQL" -maxdepth 4 -name codeql -type f | head -1)
-          if [ -z "$CODEQL_BIN" ]; then
-            echo "ERROR: codeql binary not found under $RUNNER_TOOL_CACHE/CodeQL" >&2
-            exit 1
-          fi
-          echo "$(dirname "$CODEQL_BIN")" >> "$GITHUB_PATH"
-          echo "Found codeql at: $CODEQL_BIN"
+      - name: Add codeql to PATH
+        run: find "$RUNNER_TOOL_CACHE/CodeQL" -name codeql -type f -printf '%h\n' -quit >> "$GITHUB_PATH"
 
       - name: Build CodeQL database
         run: |
@@ -64,7 +40,7 @@ jobs:
             --language=javascript \
             --source-root=.
 
-      - name: Run CodeQL analysis (security-extended)
+      - name: Run CodeQL analysis
         id: codeql-tool
         run: |
           mkdir -p codeql-results

--- a/workshop/code_scan/sast/codeQL/workflow.yml
+++ b/workshop/code_scan/sast/codeQL/workflow.yml
@@ -5,75 +5,112 @@
 # CodeQL is a static analysis tool for finding security vulnerabilities in code
 # Repository: https://github.com/github/codeql
 #
+# In this workshop CodeQL focuses on data-flow / taint vulnerabilities — its
+# sweet spot. Hardcoded secrets are NOT its job, that lives in the
+# secrets_scan module. Expect this scan to surface the command-line
+# injection at code/src/simple-app.js:41 (user-controlled `filePath` passed
+# to `child_process.exec`).
+#
+# Why we drive the analysis manually instead of using
+# `github/codeql-action/analyze`: when triggered on `pull_request`, the
+# action filters the SARIF to only include alerts the PR introduces
+# relative to the base branch. For a workshop PR that doesn't touch
+# simple-app.js, every "pre-existing" finding gets stripped — silent green.
+# Running `codeql database analyze` directly with the CLI bypasses that
+# filter and reports the full set of findings.
+#
 # TO USE THIS JOB:
 # 1. Copy this entire job definition into .github/workflows/code-scan.yml
 # 2. Replace the current jobs: definition with this one
-# 3. The job will automatically scan all code in the code/ directory
-# 4. The scan will fail if vulnerabilities are found
+# 3. The job builds a CodeQL DB from the repo, runs the security-extended
+#    suite, and counts findings from the resulting SARIF.
+# 4. The scan will fail if any data-flow vulnerabilities are found.
 # =============================================================================
 
 jobs:
   codeql-scan:
     name: CodeQL SAST Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     outputs:
       result: ${{ steps.scan-result.outputs.result }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL toolchain
         uses: github/codeql-action/init@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
         with:
           languages: javascript
 
-      - name: Perform CodeQL Analysis
-        id: codeql-tool
-        uses: github/codeql-action/analyze@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
-
-      - name: Wait for GitHub to process results
-        run: sleep 30
-
-      - name: Check for CodeQL security alerts
-        id: check-findings
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Locate codeql binary
         run: |
-          # Use gh CLI to check for code scanning alerts
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ALERTS=$(gh api "repos/${{ github.repository }}/code-scanning/alerts?state=open&pr=${{ github.event.number }}&tool_name=CodeQL" 2>/dev/null || echo "[]")
+          # The init action extracts the toolchain into the runner's tool cache
+          # but doesn't put it on PATH. Find the binary and append its dir.
+          CODEQL_BIN=$(find "$RUNNER_TOOL_CACHE/CodeQL" -maxdepth 4 -name codeql -type f | head -1)
+          if [ -z "$CODEQL_BIN" ]; then
+            echo "ERROR: codeql binary not found under $RUNNER_TOOL_CACHE/CodeQL" >&2
+            exit 1
+          fi
+          echo "$(dirname "$CODEQL_BIN")" >> "$GITHUB_PATH"
+          echo "Found codeql at: $CODEQL_BIN"
+
+      - name: Build CodeQL database
+        run: |
+          codeql database create codeql-db \
+            --language=javascript \
+            --source-root=.
+
+      - name: Run CodeQL analysis (security-extended)
+        id: codeql-tool
+        run: |
+          mkdir -p codeql-results
+          codeql database analyze codeql-db \
+            --format=sarif-latest \
+            --output=codeql-results/javascript.sarif \
+            codeql/javascript-queries:codeql-suites/javascript-security-extended.qls
+
+      - name: Summarize findings
+        if: always() && hashFiles('codeql-results/*.sarif') != ''
+        run: |
+          COUNT=$(jq '[.runs[].results[]] | length' codeql-results/*.sarif | awk '{s+=$1} END {print s}')
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
           else
-            ALERTS=$(gh api "repos/${{ github.repository }}/code-scanning/alerts?state=open&tool_name=CodeQL" 2>/dev/null || echo "[]")
+            echo "❌ Found $COUNT CodeQL finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              codeql-results/*.sarif
           fi
-          
-          ALERT_COUNT=$(echo "$ALERTS" | jq '. | length' 2>/dev/null || echo "0")
-          
-          echo "alert_count=$ALERT_COUNT" >> "$GITHUB_OUTPUT"
-          echo "Found $ALERT_COUNT CodeQL security alerts"
-          
-          if [ "$ALERT_COUNT" -gt 0 ]; then
-            echo "Alert details:"
-            echo "$ALERTS" | jq -r '.[] | "- \(.rule.id): \(.rule.severity) - \(.rule.description)"' 2>/dev/null || echo "Could not parse alerts"
-          fi
+
+      - name: Upload SARIF to GitHub Advanced Security
+        if: always() && hashFiles('codeql-results/*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: codeql-results
+          category: codeql
 
       - name: Set scan result
         id: scan-result
         if: always()
         run: |
-          ALERT_COUNT="${{ steps.check-findings.outputs.alert_count }}"
-          
           if [ "${{ steps.codeql-tool.outcome }}" != "success" ]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ CodeQL scan encountered an error"
             exit 1
-          elif [ "$ALERT_COUNT" -gt 0 ]; then
+          fi
+          if ! ls codeql-results/*.sarif >/dev/null 2>&1; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "✅ CodeQL scan completed - no SARIF produced (no findings)"
+            exit 0
+          fi
+          COUNT=$(jq '[.runs[].results[]] | length' codeql-results/*.sarif | awk '{s+=$1} END {print s}')
+          if [ "${COUNT:-0}" -gt 0 ]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ CodeQL found $ALERT_COUNT security alert(s)"
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+tool%3ACodeQL"
-            else
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=tool%3ACodeQL"
-            fi
+            echo "❌ CodeQL found $COUNT security alert(s)"
             exit 1
           else
             echo "result=success" >> "$GITHUB_OUTPUT"

--- a/workshop/code_scan/sca/osv-scanner/workflow.yml
+++ b/workshop/code_scan/sca/osv-scanner/workflow.yml
@@ -1,0 +1,74 @@
+# =============================================================================
+# OSV-SCANNER CODE SCAN (SCA) JOB
+# =============================================================================
+#
+# osv-scanner queries Google's OSV.dev database — an open-standard
+# vulnerability feed that aggregates GitHub Advisories, RustSec, PyPA,
+# GoVulnDB and more. No NVD dependency, no API keys, lockfile-based.
+# Repository: https://github.com/google/osv-scanner
+#
+# TO USE THIS JOB:
+# 1. Copy this entire job definition into .github/workflows/code-scan.yml
+# 2. Replace the current jobs: definition with this one
+# 3. The job scans ./code for vulnerable libraries
+# 4. The scan will fail if any known vulnerabilities are found
+# =============================================================================
+
+jobs:
+  code-scan:
+    name: Code Scan with osv-scanner (SCA)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    outputs:
+      result: ${{ steps.scan-result.outputs.result }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run osv-scanner
+        id: scan-tool
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        with:
+          scan-args: |-
+            --recursive
+            --format=sarif
+            --output-file=osv-scanner.sarif
+            ./code
+
+      - name: Summarize findings
+        if: always() && hashFiles('osv-scanner.sarif') != ''
+        run: |
+          COUNT=$(jq '[.runs[].results[]] | length' osv-scanner.sarif)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "✅ No vulnerabilities found"
+          else
+            echo "❌ Found $COUNT vulnerability finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              osv-scanner.sarif
+          fi
+
+      - name: Upload SARIF to GitHub Advanced Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: osv-scanner.sarif
+          category: osv-scanner-sca
+
+      - name: Set scan result
+        id: scan-result
+        if: always()
+        run: |
+          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "✅ Code scan passed - no vulnerabilities found"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "❌ Code scan failed - vulnerabilities detected"
+            exit 1
+          fi

--- a/workshop/code_scan/sca/osv-scanner/workflow.yml
+++ b/workshop/code_scan/sca/osv-scanner/workflow.yml
@@ -2,9 +2,8 @@
 # OSV-SCANNER CODE SCAN (SCA) JOB
 # =============================================================================
 #
-# osv-scanner queries Google's OSV.dev database — an open-standard
-# vulnerability feed that aggregates GitHub Advisories, RustSec, PyPA,
-# GoVulnDB and more. No NVD dependency, no API keys, lockfile-based.
+# osv-scanner is a vulnerability scanner for project dependencies, backed
+# by the OSV.dev database.
 # Repository: https://github.com/google/osv-scanner
 #
 # TO USE THIS JOB:

--- a/workshop/container_scan/README.md
+++ b/workshop/container_scan/README.md
@@ -38,20 +38,11 @@ By the end of this module, you will:
 - [🔜] Identify Dockerfile security best practices
 
 > [!TIP]
-> **The fix can have layers.** The workshop's `code/Dockerfile` ships with
-> an outdated base image, so the obvious first move is to bump it. That
-> removes most CVEs (the ones in the OS packages and the language runtime
-> binary) but does not always produce a clean scan: transitive
-> dependencies bundled inside the new base image — for example, the
-> libraries that ship with the global `npm` CLI — may still surface as
-> HIGH findings. A clean scan often requires both:
->
-> 1. **Bump the base image** (e.g., `FROM node:16.14.0-alpine` → `FROM node:25-alpine`).
-> 2. **Refresh the bundled deps inside the image** (e.g., `RUN npm install -g npm@11.13.0 && npm cache clean --force`).
->
-> Real-world security has layers: the base image is one, the transitive
-> deps it ships are another. Bumping the base is necessary but not always
-> sufficient — re-run the scanner between each step to see what's left.
+> **A clean scan can take more than one fix.** Bumping the base image
+> clears OS-package and language-runtime CVEs, but transitive dependencies
+> bundled inside the new image (e.g., libraries shipped with the global
+> package manager) may still surface as HIGH findings. Expect to fix in
+> layers — re-run the scanner between each change to see what's left.
 
 ## Security Checklist
 

--- a/workshop/container_scan/README.md
+++ b/workshop/container_scan/README.md
@@ -37,6 +37,22 @@ By the end of this module, you will:
 - Understand supply chain security for containers
 - [🔜] Identify Dockerfile security best practices
 
+> [!TIP]
+> **The fix can have layers.** The workshop's `code/Dockerfile` ships with
+> an outdated base image, so the obvious first move is to bump it. That
+> removes most CVEs (the ones in the OS packages and the language runtime
+> binary) but does not always produce a clean scan: transitive
+> dependencies bundled inside the new base image — for example, the
+> libraries that ship with the global `npm` CLI — may still surface as
+> HIGH findings. A clean scan often requires both:
+>
+> 1. **Bump the base image** (e.g., `FROM node:16.14.0-alpine` → `FROM node:25-alpine`).
+> 2. **Refresh the bundled deps inside the image** (e.g., `RUN npm install -g npm@11.13.0 && npm cache clean --force`).
+>
+> Real-world security has layers: the base image is one, the transitive
+> deps it ships are another. Bumping the base is necessary but not always
+> sufficient — re-run the scanner between each step to see what's left.
+
 ## Security Checklist
 
 - [ ] **Use minimal, trusted base images** and rebuild them regularly.

--- a/workshop/container_scan/grype/workflow.yml
+++ b/workshop/container_scan/grype/workflow.yml
@@ -80,10 +80,10 @@ jobs:
         run: |
           if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ Container scan passed - no critical vulnerabilities found"
+            echo "✅ Container scan passed - no vulnerabilities at or above the configured severity threshold"
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ Container scan failed - critical vulnerabilities detected"
+            echo "❌ Container scan failed - vulnerabilities at or above the configured severity threshold detected"
             echo "🔍 View security findings for this PR:"
             echo "https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.pull_request.number }}+is%3Aopen"
             exit 1

--- a/workshop/container_scan/trivy/workflow.yml
+++ b/workshop/container_scan/trivy/workflow.yml
@@ -70,10 +70,10 @@ jobs:
         run: |
           if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ Container scan passed - no critical vulnerabilities found"
+            echo "✅ Container scan passed - no vulnerabilities at or above the configured severity threshold"
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ Container scan failed - critical vulnerabilities detected"
+            echo "❌ Container scan failed - vulnerabilities at or above the configured severity threshold detected"
             exit 1
           fi
 

--- a/workshop/pipeline_scan/zizmor/workflow.yml
+++ b/workshop/pipeline_scan/zizmor/workflow.yml
@@ -31,3 +31,7 @@ jobs:
         uses: zizmorcore/zizmor-action@main
         with:
           min-severity: "high"
+          # Online audits (impostor-commit, repojacking, known-vulnerable-actions, artipacked)
+          # hard-crash the entire run on any GitHub API HTTP error. With github/codeql-action
+          # SHA pins this is deterministic — see zizmor#1252 / #1874.
+          online-audits: "false"

--- a/workshop/pipeline_scan/zizmor/workflow.yml
+++ b/workshop/pipeline_scan/zizmor/workflow.yml
@@ -31,7 +31,6 @@ jobs:
         uses: zizmorcore/zizmor-action@main
         with:
           min-severity: "high"
-          # Online audits (impostor-commit, repojacking, known-vulnerable-actions, artipacked)
-          # hard-crash the entire run on any GitHub API HTTP error. With github/codeql-action
-          # SHA pins this is deterministic — see zizmor#1252 / #1874.
+          # Disable online audits — they hard-crash the run on any GitHub API HTTP error
+          # (see zizmor#1252 / #1874).
           online-audits: "false"

--- a/workshop/secrets_scan/trufflehog/workflow.yml
+++ b/workshop/secrets_scan/trufflehog/workflow.yml
@@ -31,8 +31,12 @@ jobs:
           # Install TruffleHog
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
-          # Run filesystem scan
-          trufflehog filesystem . --results=verified,unknown --fail
+          # Run filesystem scan.
+          # `unverified` is included so the workshop's didactic AKIA in
+          # code/src/simple-app.js (which AWS rejects as invalid) still
+          # triggers a failure. Without it, trufflehog discards the match
+          # as a false positive and the module silently passes.
+          trufflehog filesystem . --results=verified,unknown,unverified --fail
 
       - name: Set scan result
         id: scan-result

--- a/workshop/secrets_scan/trufflehog/workflow.yml
+++ b/workshop/secrets_scan/trufflehog/workflow.yml
@@ -31,11 +31,8 @@ jobs:
           # Install TruffleHog
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
-          # Run filesystem scan.
-          # `unverified` is included so the workshop's didactic AKIA in
-          # code/src/simple-app.js (which AWS rejects as invalid) still
-          # triggers a failure. Without it, trufflehog discards the match
-          # as a false positive and the module silently passes.
+          # Include `unverified` so detected-but-unverifiable secrets still fail the build
+          # (the workshop's didactic AKIA is invalid and would otherwise be silently dropped).
           trufflehog filesystem . --results=verified,unknown,unverified --fail
 
       - name: Set scan result


### PR DESCRIPTION
## Context

I walked through the workshop end-to-end as a first-time attendee a few weeks ago, recorded the friction, and turned each blocker / silent-pass into a concrete fix. The dry-run notes (per-module status, repro steps, trade-offs) live at the linked report. This MR bundles the eight commits that came out of it.

📝 Dry-run report: <https://github.com/sanchezpaco/secure-pipeline-workshop/blob/workshop-improvements/docs/dry-run/report.md>

The commits are independent and each one should make sense on its own — happy to split into smaller PRs if that's easier to review.

## What's fixed, by group

### 🟢 Quick wins — workflow flag/wording fixes (commits 1–4)

- **\`fix(pipeline_scan): disable zizmor online audits to keep module runnable\`**
  zizmor v1.24.x's online audits hard-crash the run on any GitHub API HTTP error. With \`github/codeql-action\` SHA pins this is deterministic — the compare API returns 404 for cross-era refs and zizmor retries until rate-limited (~17 min, ~2500 calls per invocation). Setting \`online-audits: \"false\"\` keeps the module runnable; we lose four online checks (repojacking, known-vulnerable-actions, impostor-commit, artipacked) but keep the bulk (unpinned-uses, template-injection, excessive-permissions, etc.). Tracking upstream: zizmorcore/zizmor#1252, #1874.

- **\`fix(secrets_scan): include unverified results in trufflehog so didactic AKIA fails\`**
  The didactic AKIA in \`code/src/simple-app.js\` is fake → AWS rejects it as invalid → trufflehog's default \`--results=verified,unknown\` discards it as a false positive → exit 0, silent green. Adding \`unverified\` makes the AKIA trigger a fail as the workshop intends.

- **\`fix(container_scan): align scan-result wording with severity-cutoff\`**
  Both grype and trivy use \`severity-cutoff: high\`, but the failure message says "critical vulnerabilities detected". Attendees go looking for criticals that aren't there. Reword to "vulnerabilities at or above the configured severity threshold detected".

- **\`fix(dast): replace dead-end placeholder with explicit 'coming soon' message\`**
  Today \`.github/workflows/dast.yml\` instructs attendees to "Copy from \`workshop/dast/{tool}/workflow.yml\`", but that path does not exist. Replace the misleading placeholder with an explicit no-op until the DAST module is shipped.

### 🟡 SCA module — make it actually work without external setup (commits 5–6)

- **\`feat(code_scan): add osv-scanner as a key-free SCA alternative to Dependency Check\`**
  Since 2024 NVD aggressively rate-limits unauthenticated clients, so OWASP Dependency Check effectively returns 0 findings without an \`NVD_API_KEY\` — silent false-pass. Add \`workshop/code_scan/sca/osv-scanner/workflow.yml\` (queries OSV.dev, no external setup) as a second alternative. README updated to split SAST/SCA sections, document the heads-up about NVD, and explain the two DB-source philosophies (open-standard OSV.dev vs. NVD-direct).

- **\`feat(code): swap lodash for axios as the didactic SCA target\`**
  \`lodash@4.17.x\` is no longer maintained — newer CVEs (CVE-2025-13465, CVE-2026-2950, CVE-2026-4800) affect the entire 4.x line with no patched release, so the standard SCA pedagogy "scan reports vuln → bump to patched version → re-scan green" silently breaks. Swap to \`axios@1.6.0\` which has a clean bump-to-fix path (CVE-2024-39338 SSRF and CVE-2025-27152 URL bypass, fixed by \`axios@1.8.2+\`). Also wire axios into \`simple-app.js\` with a \`/fetch\` endpoint that proxies a user-controlled URL — amplifying the lib-level CVE into an exploitable SSRF and reinforcing the cross-module lesson "lib bug + missing validation = exploitable".

### 🔵 Deeper module rewrites (commits 7–8)

- **\`docs(container_scan): document the 2-step fix path (base image + bundled deps)\`**
  In 2026, "just bump the base image" is not enough to clean the container scan: \`node:25-alpine\` still ships a HIGH in \`picomatch\` bundled inside the npm CLI. Document the 2-step lesson in the module README — bump base, then \`RUN npm install -g npm@11.13.0 && npm cache clean --force\` to refresh the bundled tree. Verified working combos: \`node:20-alpine + npm@11.13.0\`, \`node:25-alpine + npm@11.13.0\`.

- **\`fix(code_scan): rewrite CodeQL placeholder to drive analysis via CLI\`**
  The previous CodeQL placeholder had two bugs that produced silent green on PR triggers: (1) it counted findings via \`gh api .../code-scanning/alerts?pr=<n>\` which returns [] without a baseline on main; (2) even after switching to the SARIF that \`codeql-action/analyze\` writes, the action itself applies a diff-aware filter on \`pull_request\` events, stripping results whose source file isn't in the PR diff. Rewrite to drive analysis manually: use \`init\` only to install the toolchain, then \`codeql database create\` + \`codeql database analyze\` directly. Also count findings via jq from the unfiltered SARIF and pretty-print rule id + message + location. Module philosophy clarified at top of file: CodeQL focuses on data-flow vulns; expect to surface \`js/command-line-injection\` at \`code/src/simple-app.js:41\`. Hardcoded secret detection is the secrets_scan module's job.

## Verification

Each fix was verified end-to-end by substituting the workshop placeholder into a fork branch and running the orchestrator. The dry-run report links to the per-module CI runs.

I deliberately did not touch:
- \`workshop/ai_scan/\` — the dry-run flagged it for a deeper revamp (multi-provider, prompt-injection guardrails, ollama fallback) that is out of scope for this MR. Happy to open a separate issue/MR for it.
- The \`upload\` step on the codeql-action — this MR keeps SARIF being uploaded to GitHub Advanced Security so the Security tab continues to work.

Happy to iterate or split if any of these conflict with the maintainers' direction.