### PR TITLE
fix(pipeline_scan): make zizmor snippet fail the build on findings

### DIFF
--- a/workshop/pipeline_scan/zizmor/workflow.yml
+++ b/workshop/pipeline_scan/zizmor/workflow.yml
@@ -28,9 +28,15 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
+        id: zizmor
         uses: zizmorcore/zizmor-action@main
         with:
           min-severity: "high"
           # Disable online audits — they hard-crash the run on any GitHub API HTTP error
           # (see zizmor#1252 / #1874).
           online-audits: "false"
+
+      - name: Fail on findings
+        if: always()
+        run: |
+          test "$(jq '[.runs[].results[]] | length' "${{ steps.zizmor.outputs.output-file }}")" -eq 0


### PR DESCRIPTION
## Problem

The current zizmor snippet (`workshop/pipeline_scan/zizmor/workflow.yml`) uses `zizmorcore/zizmor-action` with its default `advanced-security: true`. Under that mode the action passes `--format=sarif` to zizmor, and per zizmor's design [SARIF output suppresses the elevated exit codes (11..14)](https://docs.zizmor.sh/usage/) that would otherwise propagate findings.

Net effect on the workshop: **the pipeline-scan stage passes green even when zizmor reports High-severity findings**. That's the exact opposite of the shift-left lesson the module is meant to teach. The action's own README [acknowledges this](https://github.com/zizmorcore/zizmor-action#readme) (`In this mode, the action will not fail when zizmor produces findings`) and recommends GitHub Rulesets, but a workshop-grade fix should make the failure visible in the job log itself.

## Evidence

Empirical reproduction on a fork using current `main` workflows. Three configurations of the same scanner:

| Config | `advanced-security` | zizmor exit | Job | Findings reported |
|---|---|---|---|---|
| A — current snippet | `true` (default) | 0 | ✅ green | 5 High in SARIF (silently swallowed) |
| B — annotations only | `false` + `annotations: true` | 14 | ❌ red | 5 High as GHA annotations |
| C — SARIF + post-gate (this PR) | `true` + parser step | 0 → parser exit 1 | ❌ red | 5 High parsed; SARIF still uploaded to GHAS |

Run for reference: https://github.com/sanchezpaco/secure-pipeline-workshop/actions/runs/25211902709

The 5 findings on current `main` are real and actionable:
- 2× `template-injection` (HIGH) at `.github/workflows/deploy-application.yml:21,23`
- 3× `unpinned-uses` introduced by the experiment harness itself (not representative)

## Fix

Keep `advanced-security: true` so SARIF still uploads to GHAS Code Scanning, and add a post-step that parses the SARIF file referenced by `steps.zizmor.outputs.output-file` and exits 1 if any finding is present. The step's `if: always()` guarantees it runs even when the action's own step is skipped or short-circuits.

Verified with the same fixture: https://github.com/sanchezpaco/secure-pipeline-workshop/actions/runs/25212196617 — `Run zizmor` step ✓ green, SARIF uploaded, `Fail on findings` step ✗ red, job overall fails as intended.

## Tradeoffs considered

- **`advanced-security: false` + `annotations: true`** — simpler (no extra step), but loses GHAS Code Scanning UI, alert tracking across PRs, and dismissal/triage flow. Reasonable for a workshop that doesn't want to depend on GHAS, but the workshop's existing snippet already opts into the GHAS path, so keeping it is the lower-friction change.
- **GitHub Rulesets / Code Scanning merge-protection** — what the action's README recommends. Job stays green, PR cannot be merged. Right answer at org scale, wrong answer for a workshop because (a) it requires repo/org config the attendee doesn't control on a fork, and (b) the failure is invisible in the job log, which weakens the didactic feedback loop.

## Caveat

The pattern depends on `steps.<id>.outputs.output-file`, which the action only exposes from [zizmorcore/zizmor-action#87 (2026-02-01)](https://github.com/zizmorcore/zizmor-action/pull/87) onward. The snippet pins the action to `@main`, so the latest is always picked up; if a future version of the workshop pins to a SHA, ensure it's post-#87.