### PR TITLE
fix(code_scan): drop dangling output ref + scope Semgrep to SAST only

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,10 +1,6 @@
 name: SAST/SCA Security Analysis
 on:
   workflow_call:
-    outputs:
-      scan-result:
-        description: "SAST/SCA scan summary"
-        value: ${{ jobs.summary.outputs.result }}
 
 permissions:
   contents: read

--- a/workshop/code_scan/sast/semgrep/workflow.yml
+++ b/workshop/code_scan/sast/semgrep/workflow.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           semgrep \
             --config=p/security-audit \
-            --config=p/secrets \
             --config=p/javascript \
             --config=p/owasp-top-ten \
             --error \


### PR DESCRIPTION
Two small cleanups to the code-scan module.

## 1. Drop dangling \`workflow_call\` output

\`.github/workflows/code-scan.yml\` declared:

\`\`\`yaml
on:
  workflow_call:
    outputs:
      scan-result:
        value: \${{ jobs.summary.outputs.result }}
\`\`\`

There is no \`summary\` job in the placeholder, nor in any of the per-tool snippets under \`workshop/code_scan/{sast,sca}/\`. The orchestrator does not consume this output either (\`grep -r 'code-scan.*scan-result' .github/workflows/\` returns only this declaration). It's a dangling reference that confuses anyone inspecting how the workflows compose. Removed.

## 2. Remove \`--config=p/secrets\` from the Semgrep snippet

The Semgrep snippet at \`workshop/code_scan/sast/semgrep/workflow.yml\` ran with:

\`\`\`yaml
semgrep \\
  --config=p/security-audit \\
  --config=p/secrets \\
  --config=p/javascript \\
  --config=p/owasp-top-ten \\
  ...
\`\`\`

\`p/secrets\` includes detectors for \`AKIA…\` and \`aws_secret_access_key\` patterns — the exact bait for **Module 3 (Secrets Scan)**. So an attendee who picks Semgrep in Module 2 sees:

- 1× \`detect-child-process\` (the intended Module 2 bait)
- 1× \`detected-aws-access-key-id-value\` at \`code/src/simple-app.js:4\` (Module 3 territory)
- 1× \`detected-aws-secret-access-key\` at \`code/src/simple-app.js:5\` (Module 3 territory)

If they fix all three, Module 3 (\`secrets-scan\` with TruffleHog or Gitleaks) has nothing to find when they reach it. The lesson collapses.

After dropping \`p/secrets\`, Semgrep finds the same single bait that CodeQL finds, and Module 3 stays intact.

## Verification

Empirical, both tools on the same \`code/\` directory (this branch):

| Tool | Findings | Location |
|------|----------|----------|
| CodeQL (local, \`javascript-security-extended.qls\`) | 1: \`js/command-line-injection\` | \`simple-app.js:42\` |
| Semgrep (after this PR, CI run) | 1: \`detect-child-process\` | \`simple-app.js:42\` |

CI run that proves Semgrep with the new config detects the bait and fails the build correctly: https://github.com/sanchezpaco/secure-pipeline-workshop/actions/runs/25214395030

## Why didactically

Both tools in Module 2 should converge on the same intended finding so attendees see "alternatives, configured differently, same outcome" rather than "Semgrep also pre-empts the next module." Same principle as the Module 1 cleanup (PR #49) where Claws and zizmor were aligned to a single bait.