### PR TITLE
fix(module-5): align Checkov and Trivy IaC on a shared bait

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -119,12 +119,13 @@ resource "aws_security_group" "ecs_tasks" {
 
   ingress {
     description = "HTTP from ALB"
-    from_port   = 0
-    to_port     = 0
+    from_port   = 22
+    to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # trivy:ignore:AVD-AWS-0104
   egress {
     description = "HTTPS outbound"
     from_port   = 443

--- a/workshop/iac_scan/checkov/workflow.yml
+++ b/workshop/iac_scan/checkov/workflow.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           directory: infra/
           framework: terraform
+          quiet: true
 
       - name: Set scan result
         id: scan-result


### PR DESCRIPTION
## Problem

Module 5 (IaC Security Scan) lists Checkov and Trivy as the two tool options the attendee can choose from. Each has a snippet under `workshop/iac_scan/`. The two snippets work against the same `infra/` Terraform code, but on the current `main` they produce **non-overlapping** findings:

| Tool | Pre-fix on current `main` | Detects the planted ingress bait? |
|------|---------------------------|-----------------------------------|
| Checkov | 3 fails (CKV_AWS_24/25/260) on the ingress block | ✅ |
| Trivy IaC | 1 CRITICAL (`AVD-AWS-0104`) on the **egress** block | ❌ |

Two consequences:

1. **Attendee picks Trivy → never sees the planted bait.** Trivy reads `from_port=0, to_port=0, cidr_blocks=["0.0.0.0/0"]` as "no specific ports open" rather than "all ports open" (Checkov does the latter). It only flags the unrelated egress block. The lesson the module is trying to teach simply doesn't reach the attendee.

2. **Even after the documented fix, Trivy stays red.** The fix the SRE-team note in `main.tf:112-113` hints at (`data.aws_vpc.existing.cidr_block` + a real port range) only touches the ingress block. Trivy's egress finding is unaffected, so the post-fix orchestrator stays failing on Trivy. There is already a `# trivy:ignore:AVD-AWS-0104` on the **HTTP** egress block (port 80) but no equivalent on the **HTTPS** egress block (port 443) — so the asymmetry leaks the unrelated finding through.

## Fix (three small changes)

### 1. Make the bait port range explicit

```diff
   ingress {
     description = "HTTP from ALB"
-    from_port   = 0
-    to_port     = 0
+    from_port   = 22
+    to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
```

Both tools now detect it as the same finding shape:

- Checkov fires `CKV_AWS_24` ("ingress 0.0.0.0/0 to port 22")
- Trivy fires `AVD-AWS-0107 HIGH` ("unrestricted ingress from any IP")

### 2. Mirror the existing `trivy:ignore` to the HTTPS egress

```diff
+  # trivy:ignore:AVD-AWS-0104
   egress {
     description = "HTTPS outbound"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
```

The HTTP egress block (port 80) already has this comment. Both egress blocks are legitimate runtime requirements of the workshop app (HTTPS for outbound API calls, HTTP for redirects). Neither is part of Module 5's lesson, so suppressing both consistently keeps the focus on the ingress bait.

### 3. Pass `quiet: true` to the Checkov action

```diff
   uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
   with:
     directory: infra/
     framework: terraform
+    quiet: true
```

The action's `quiet: true` maps to `checkov --quiet`, which prints only the failed checks. Without it the run log buries the 1-3 actual failures under ~30 `Check: ... Passed for resource: ...` lines. With it, the attendee sees exactly the failures they need to fix.

## Verification

End-to-end on a test PR running both Checkov and Trivy IaC in parallel against the same `infra/`: https://github.com/sanchezpaco/secure-pipeline-workshop/pull/12

| Stage | Checkov | Trivy IaC |
|-------|---------|-----------|
| Bait (`from_port=22, cidr_blocks=["0.0.0.0/0"]`) | ❌ `CKV_AWS_24` | ❌ `AVD-AWS-0107 HIGH` |
| Fix (`data.aws_vpc.existing.cidr_block`, port 3000) | ✅ Passed checks: 34, Failed: 0 | ✅ no failures |

CI runs:

- Bait failing on both: https://github.com/sanchezpaco/secure-pipeline-workshop/actions/runs/25216577656
- Fix passing on both: https://github.com/sanchezpaco/secure-pipeline-workshop/actions/runs/25216615393

## Why this matters didactically

Module 5 lets the attendee pick between Checkov and Trivy IaC. Before this PR, that choice silently changed whether the lesson reached them at all. After this PR, both tools fire on the same single finding, the attendee applies the same fix, and both go to 0. Same shape as Modules 1, 2 and 4 cleanups (see PRs #48, #49, #50, #51).

## Related

Independent from #48, #49, #50 and #51. Composes cleanly with all of them.