### PR TITLE
Workshop UX: collapsible Solutions sections + uniform Summarize findings step

### DIFF
--- a/workshop/code_scan/README.md
+++ b/workshop/code_scan/README.md
@@ -67,3 +67,88 @@ By the end of this module, you will:
 - [ ] Security hotspots addressed
 - [ ] False positive management
 - [ ] Security metrics tracking
+
+## Solutions (spoilers — open only when stuck)
+
+> The bait for this module lives in two places: a vulnerable code pattern in `code/src/simple-app.js` (SAST) and a known-vulnerable dependency in `code/package.json` (SCA). The CI failures are intentional.
+
+<details>
+<summary><b>CodeQL (SAST)</b> — <code>js/command-line-injection</code> at <code>code/src/simple-app.js:42</code></summary>
+
+**What CodeQL flagged**: `exec(\`cat "${filePath}"\`, …)` flows the user-controlled `filePath` from the request body straight into a shell command. The TODO comment on the line above (`// TODO: Tech debt - should use fs.readFile instead of shell command for security`) hints at the intended fix.
+
+**Reading the output**: the snippet's `Summarize findings` step prints `ruleId | message | path:line` — exactly the format you need.
+
+**Fix** — replace the `exec(...)` with `fs.readFile(...)` confined to a safe base directory (the `path.resolve` + `startsWith` guard also clears any follow-up path-traversal rule):
+
+```js
+if (filePath) {
+  const fs = require('fs');
+  const path = require('path');
+
+  const safeBase = path.resolve(__dirname, 'public');
+  const resolved = path.resolve(safeBase, filePath);
+  if (!resolved.startsWith(safeBase + path.sep)) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Invalid path' }));
+    return;
+  }
+
+  fs.readFile('./config.json', 'utf8', (configErr, configData) => {
+    const config = configErr ? { debug: false } : JSON.parse(configData);
+
+    fs.readFile(resolved, 'utf8', (error, stdout) => {
+      if (error) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: error.message }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ config: config, content: stdout }));
+    });
+  });
+}
+```
+
+> Heads-up on CI wall-clock: each CodeQL run takes 4-5 minutes (init + database create + analyze). It's not stuck.
+
+</details>
+
+<details>
+<summary><b>Semgrep (SAST)</b> — <code>javascript.lang.security.audit.detect-child-process</code> at <code>code/src/simple-app.js:42</code></summary>
+
+**Reading the output**: Semgrep's job log only prints `Findings: 1 (1 blocking)` — no rule ID, no file/line. To see what failed, either open the GitHub Code Scanning tab (if your fork has GHAS) or download `semgrep-results.sarif` (you may want to add `actions/upload-artifact` to the snippet for this — it's missing by default).
+
+**Same root cause as CodeQL**: the `exec(\`cat "${filePath}"\`, …)` line.
+
+**Fix** — identical to the CodeQL fix above.
+
+</details>
+
+<details>
+<summary><b>osv-scanner (SCA)</b> — multiple CVEs on <code>axios@1.6.0</code> in <code>code/package.json</code></summary>
+
+**What osv-scanner flagged**: `axios@1.6.0` has multiple known CVEs (SSRF, DoS, credential leakage, etc.). The snippet's `Summarize findings` step prints them as `CVE-… | Package … is vulnerable to …`.
+
+**Fix** — bump `axios` to a recent patched version. Don't pick the lowest version that closes a single CVE; pick the latest stable patch level (CVEs in the same package keep coming):
+
+```diff
+   "dependencies": {
+-    "axios": "1.6.0"
++    "axios": "1.15.2"
+   }
+```
+
+Then regenerate the lockfile so it stays in sync with `package.json`:
+
+```bash
+cd code
+rm -f package-lock.json
+npm install --package-lock-only
+cd ..
+git add code/package.json code/package-lock.json
+```
+
+> Tip: `npm view axios versions` lists the available versions. At the time of writing `1.15.2` was clean; check the latest before committing.
+
+</details>

--- a/workshop/code_scan/sast/semgrep/workflow.yml
+++ b/workshop/code_scan/sast/semgrep/workflow.yml
@@ -37,6 +37,19 @@ jobs:
             --output=semgrep-results.sarif \
             ./code/ || echo "SEMGREP_EXIT_CODE=$?" >> "$GITHUB_ENV"
 
+      - name: Summarize findings
+        if: always() && hashFiles('semgrep-results.sarif') != ''
+        run: |
+          COUNT=$(jq '[.runs[].results[]] | length' semgrep-results.sarif)
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Semgrep finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              semgrep-results.sarif
+          fi
+
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
         with:

--- a/workshop/container_scan/README.md
+++ b/workshop/container_scan/README.md
@@ -64,3 +64,38 @@ By the end of this module, you will:
 
 ### Other Tools
 - [slimtoolkit/slim](https://github.com/slimtoolkit/slim): Tool to reduce the size of container images (making them more secure).
+
+## Solutions (spoilers — open only when stuck)
+
+> The container bait is the **base image** in `code/Dockerfile` — it ships with an EOL alpine that has unpatched HIGHs. The CI failure is intentional.
+
+<details>
+<summary><b>Trivy</b> — alpine OS-layer HIGHs (<code>musl</code>, etc.)</summary>
+
+**What Trivy flagged**: an `alpine 3.19.4` base ships `musl` / `musl-utils` HIGHs (e.g. `CVE-2025-26519`, `CVE-2026-40200`) and EOL warnings.
+
+**Reading the output**: Trivy prints a clean table (Library / Vulnerability / Severity / Status / Installed Version / Fixed Version / Title). This is the gold-standard output across the workshop.
+
+> ⚠️ **Don't just bump alpine minor**: `node:20-alpine3.19` → `node:20-alpine3.21` actually *increases* the finding count (alpine 3.21 still ships an unpatched openssl). Jump to a current node-major instead.
+
+> ⚠️ **"Fixed Version" is per-CVE, not per-package**: bumping to the version Trivy lists in that column only closes the CVE you happened to look at. Pick the latest stable image tag.
+
+**Fix** — bump the base image:
+
+```diff
+-FROM node:20-alpine3.19
++FROM node:25-alpine
+```
+
+</details>
+
+<details>
+<summary><b>Grype</b> — same root cause, terser output</summary>
+
+**What Grype reports**: a single line — `[…] ERROR discovered vulnerabilities at or above the severity threshold` — plus a helpful warning: `188 packages from EOL distro "alpine 3.19.4"`. The actual CVE list is uploaded as SARIF to the GitHub Code Scanning tab; if your fork doesn't have GHAS, the run page shows nothing actionable. Two snippet improvements help: switch `output-format: sarif` to `table` for the workshop, or upload the SARIF as an `actions/upload-artifact`.
+
+**Same root cause as Trivy**: EOL alpine base.
+
+**Fix** — identical to the Trivy fix above.
+
+</details>

--- a/workshop/container_scan/grype/workflow.yml
+++ b/workshop/container_scan/grype/workflow.yml
@@ -67,6 +67,20 @@ jobs:
           output-format: sarif
           add-cpes-if-none: true
 
+      - name: Summarize findings
+        if: always() && steps.scan-tool.outputs.sarif != ''
+        run: |
+          SARIF="${{ steps.scan-tool.outputs.sarif }}"
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Grype finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
       - name: Upload SARIF to GitHub Advanced Security
         if: always()
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2

--- a/workshop/iac_scan/README.md
+++ b/workshop/iac_scan/README.md
@@ -133,3 +133,46 @@ By the end of this module, you will:
 
 ### Other Tools
 - [DataDog/terraform-provider-terrapwner](https://github.com/DataDog/terraform-provider-terrapwner): Terrapwner is a security-focused Terraform provider designed for testing and validating CI/CD pipelines.
+
+## Solutions (spoilers — open only when stuck)
+
+> The bait is a single misconfigured ingress rule in `infra/main.tf`. Both scanners (Checkov and Trivy IaC) flag the same line range. One fix clears both.
+
+<details>
+<summary><b>Checkov</b> — <code>CKV_AWS_24</code> at <code>infra/main.tf:120-126</code></summary>
+
+**What Checkov flagged**: `aws_security_group.ecs_tasks` has an ingress rule with `description = "HTTP from ALB"` but `from_port = 22 / to_port = 22` and `cidr_blocks = ["0.0.0.0/0"]` — i.e. SSH open to the whole internet. Classic copy-paste/typo bait.
+
+**Reading the output**: Checkov (with `quiet: true`) prints only failed checks plus a summary like `Passed checks: 18, Failed checks: 1`. The output names the rule, the resource, the file, the line range, and quotes the offending lines. Best output in the module.
+
+**Fix** — close SSH-from-anywhere and reopen on the actual app port, restricted to the VPC CIDR. The SRE note above the resource literally hands you the data source you need (`data.aws_vpc.existing.cidr_block`):
+
+```diff
+   ingress {
+-    description = "HTTP from ALB"
+-    from_port   = 22
+-    to_port     = 22
++    description = "HTTP from ALB (workshop)"
++    from_port   = 3000
++    to_port     = 3000
+     protocol    = "tcp"
+-    cidr_blocks = ["0.0.0.0/0"]
++    cidr_blocks = [data.aws_vpc.existing.cidr_block]
+   }
+```
+
+</details>
+
+<details>
+<summary><b>Trivy IaC</b> — <code>AVD-AWS-0107</code> on the same block</summary>
+
+**What Trivy IaC flagged**: same ingress rule (port 22 from `0.0.0.0/0`). Trivy's rule ID is `AVD-AWS-0107`.
+
+**Reading the output**: the snippet is configured for SARIF-only — the job log shows `Running Trivy with options: trivy config infra/` followed by `Successfully uploaded results` with **no rule, no file, no line**. To see the finding, either:
+- read the GitHub Code Scanning tab (requires GHAS),
+- switch the snippet's `format` from `sarif` to `table` (sacrifices the GHAS upload), or
+- add an `actions/upload-artifact` step for `trivy-results.sarif` so you can download it.
+
+**Fix** — identical to the Checkov fix above.
+
+</details>

--- a/workshop/iac_scan/trivy/workflow.yml
+++ b/workshop/iac_scan/trivy/workflow.yml
@@ -39,6 +39,19 @@ jobs:
           severity: 'CRITICAL,HIGH'
         continue-on-error: false
 
+      - name: Summarize findings
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        run: |
+          COUNT=$(jq '[.runs[].results[]] | length' trivy-results.sarif)
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Trivy IaC finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              trivy-results.sarif
+          fi
+
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2

--- a/workshop/pipeline_scan/README.md
+++ b/workshop/pipeline_scan/README.md
@@ -58,3 +58,47 @@ By the end of this module, you will:
   - [Untrusted input](https://securitylab.github.com/resources/github-actions-untrusted-input/)
   - [How to trust your building blocks](https://securitylab.github.com/resources/github-actions-building-blocks/)
   - [New vulnerability patterns and mitigation strategies](https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/)
+
+## Solutions (spoilers — open only when stuck)
+
+> Heads-up: each tool's snippet ships with one **planted bait line**. The very file you just pasted contains it on purpose. The CI failure is intentional — the goal of this section is to keep you from second-guessing whether you copy-pasted wrong.
+
+<details>
+<summary><b>Claws</b> — <code>UnpinnedAction</code> on <code>.github/workflows/pipeline-scan.yml:24</code></summary>
+
+**What Claws flagged**: the snippet's `Set Up Ruby` step uses `ruby/setup-ruby@master`, a moving ref. Per `claws-config.yml`, only `actions/*` is in `trusted_authors`; every other `uses:` must be SHA-pinned.
+
+**Fix** — pin to a tagged release SHA:
+
+```yaml
+- name: Set Up Ruby
+  uses: ruby/setup-ruby@0ecad18fe538ef70f6b82773daecc6af1a7fe58a # v1.252.0
+  with:
+    ruby-version: '3.3'
+```
+
+Use any current SHA from a tagged release of [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby/tags) — the one above is `v1.252.0` at the time of writing.
+
+</details>
+
+<details>
+<summary><b>zizmor</b> — <code>zizmor/unpinned-uses</code> on <code>.github/workflows/pipeline-scan.yml:26</code></summary>
+
+**What zizmor flagged**: the snippet's `Run zizmor 🌈` step uses `zizmorcore/zizmor-action@main` — same antipattern as the Claws example, just on zizmor's own action.
+
+**Tip on reading zizmor's output**: the job log dumps the full SARIF as JSON. Search for `"ruleId"` and `"startLine"` to find the offending line without scrolling.
+
+**Fix** — pin to a tagged release SHA:
+
+```yaml
+- name: Run zizmor 🌈
+  id: zizmor
+  uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+  with:
+    min-severity: "high"
+    online-audits: "false"
+```
+
+Use any current SHA from a tagged release of [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action/tags).
+
+</details>

--- a/workshop/pipeline_scan/zizmor/workflow.yml
+++ b/workshop/pipeline_scan/zizmor/workflow.yml
@@ -36,7 +36,17 @@ jobs:
           # (see zizmor#1252 / #1874).
           online-audits: "false"
 
-      - name: Fail on findings
-        if: always()
+      - name: Summarize findings
+        if: always() && steps.zizmor.outputs.output-file != ''
         run: |
-          test "$(jq '[.runs[].results[]] | length' "${{ steps.zizmor.outputs.output-file }}")" -eq 0
+          SARIF="${{ steps.zizmor.outputs.output-file }}"
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT zizmor finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+            exit 1
+          fi

--- a/workshop/secrets_scan/README.md
+++ b/workshop/secrets_scan/README.md
@@ -92,3 +92,46 @@ By the end of this module, you will:
 [^2]: [Analysis of GitHub Repositories Surfaces Nearly 23M Secrets](https://devops.com/analysis-of-github-repositories-surfaces-nearly-23m-secrets/)
 [^3]: [Over 12 million auth secrets and keys leaked on GitHub in 2023](https://www.bleepingcomputer.com/news/security/over-12-million-auth-secrets-and-keys-leaked-on-github-in-2023/)
 [^4]: [The State of Secrets Sprawl 2024](https://securityboulevard.com/2024/03/the-state-of-secrets-sprawl-2024/)
+
+## Solutions (spoilers — open only when stuck)
+
+> The bait is two hardcoded AWS credentials at `code/src/simple-app.js:4-5`. They're a didactic AKIA — not real and not validated against AWS — but secret scanners detect them by format. The CI failures are intentional.
+
+<details>
+<summary><b>TruffleHog</b> — <code>Detector Type: AWS</code> at <code>code/src/simple-app.js:4</code></summary>
+
+**What TruffleHog flagged**: 1 unverified result on the `AKIA…` access-key literal. The job log prints a clean block:
+
+```
+Found unverified result 🐷🔑❓
+Detector Type: AWS
+Raw result: AKIA…
+File: code/src/simple-app.js
+Line: 4
+```
+
+**Why the snippet uses `--results=verified,unknown,unverified`**: the workshop's AKIA is not a real AWS key, so TruffleHog can't validate it against AWS. Under the default `verified`-only filter the build would silently pass — the extra flags are what make the bait fire.
+
+**Fix** — move the hardcoded credentials to environment variables:
+
+```diff
+-const AWS_ACCESS_KEY_ID = 'AKIA…REDACTED'
+-const AWS_SECRET_ACCESS_KEY = '[redacted-40-char-secret]'
++const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
++const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+```
+
+</details>
+
+<details>
+<summary><b>Gitleaks</b> — <code>aws-access-token</code> + <code>generic-api-key</code> at <code>code/src/simple-app.js:4-5</code></summary>
+
+**What Gitleaks flagged**: 2 leaks — the access-key (rule `aws-access-token`) and the secret-key (rule `generic-api-key`, high-entropy match). The output has rich detail (Finding / Secret / RuleID / Entropy / File / Line / Fingerprint), but the `wget`-based install pollutes the log with a progress bar — scroll past it to find `Finding:`.
+
+**Snippet note**: the snippet uses `--no-git` so only the current filesystem is scanned, not git history. Once your latest commit is clean, Gitleaks goes green even if older commits on the branch still contain the literals.
+
+**Fix** — same as TruffleHog (move both to `process.env.*`). One edit clears both rules.
+
+</details>
+
+> ⚠️ **If you write notes inside this repo** (e.g. a `docs/` writeup that quotes the bait literals), Gitleaks will trip on your notes too. Either redact (`AKIA…REDACTED`, `[redacted-40-char-secret]`) or add a `.gitleaksignore` covering your notes path.


### PR DESCRIPTION
Two improvements that emerged from a fresh end-to-end attendee walkthrough of the workshop. Both are non-breaking and additive.

## 1. Per-module `## Solutions (spoilers)` section

Each module README now ships a `<details>`-wrapped block per tool with:
- the rule ID the scanner reports,
- the file and line of the planted bait,
- the exact diff to apply to make CI green.

The goal is to keep the workshop genuinely educational without making it a CTF: attendees who get stuck can open the spoiler and move on, instead of spending 5+ minutes second-guessing whether they pasted the snippet correctly.

Touched modules: `pipeline_scan`, `code_scan`, `secrets_scan`, `container_scan`, `iac_scan`.

## 2. Uniform `Summarize findings` step across SARIF-producing snippets

The CodeQL and osv-scanner snippets already include a 10-line `jq`-based `Summarize findings` step that prints `ruleId | message | path:line` in the job log. The other four SARIF-producing snippets did not, so their failure modes were:

- **Semgrep**: log says `Findings: 1 (1 blocking)` — no rule, no file/line.
- **Grype**: log says `ERROR discovered vulnerabilities at or above the severity threshold` — single line, no CVE list.
- **Trivy IaC**: log says `Successfully uploaded results` — nothing actionable.
- **zizmor**: dumps the full SARIF as JSON in the log — readable only with effort.

This PR adds the same `jq` summary step to all four. Attendees now get the same uniform output across every tool. zizmor's existing `Fail on findings` step is replaced (the new step both summarizes and exits 1 when count > 0).

## What's NOT in this PR

- No changes to the bait (`code/src/simple-app.js`, `code/Dockerfile`, `code/package.json`, `infra/main.tf`).
- No changes to the orchestrator workflows in `.github/workflows/` — the `🚧 Workshop Placeholder` stubs stay as-is so attendees still do the snippet copy-paste step.
- No changes to the secrets scan or osv-scanner snippets — they were already on the desired pattern.

## Validation

The summary-step changes were validated end-to-end on a fork PR against this same workshop scaffolding: each tool's bait → fix → green cycle was exercised twice (once with the original snippet, once with the new `Summarize findings` step). Output is now consistent across all six SARIF-producing tools.