### PR TITLE
docs: rewrite root index + workshop flow with prerequisites and explicit steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ The workshop is organized into different modules, each focusing on a specific as
 
 ## 📚 Workshop Modules
 
-### 0. 🐦‍🔥 [Introduction](workshop/)
-Workshop introduction.
+> 🐦‍🔥 New here? Start with the [workshop introduction](workshop/) for context on shift-left and CI/CD/CS.
 
-### 1. 🔍 [Pipeline Security Scan](workshop/pipeline_scan/)
-Learn to scan CI/CD pipelines for security misconfigurations and vulnerabilities.
+### 1. 🛡️ [Pipeline Security Scan](workshop/pipeline_scan/)
+Detect insecure GitHub Actions patterns: unpinned actions, excessive permissions, untrusted authors.
 
 ### 2. 🔬 [Code Security Analysis](workshop/code_scan/)
-Implement SAST (Static Application Security Testing) and SCA (Software Composition Analysis).
+Find vulnerabilities in your application code (SAST) and in its dependencies (SCA).
 
 ### 3. 🔐 [Secrets Scan](workshop/secrets_scan/)
 Detect and prevent exposure of credentials and sensitive information.
@@ -32,15 +31,14 @@ Detect and prevent exposure of credentials and sensitive information.
 ### 4. 🐳 [Container Security Scanning](workshop/container_scan/)
 Scan Docker images for vulnerabilities and misconfigurations.
 
-### 5. 🏗️ [Infrastructure Security Scan](workshop/iac_scan/)
-Analyze Infrastructure as Code for security issues.
+### 5. 🏗️ [Infrastructure as Code (IaC) Security Scan](workshop/iac_scan/)
+Analyze Terraform and other IaC definitions for security issues before they are deployed.
 
-### 6. 🔍 [Runtime Infrastructure Scan](workshop/runtime_infra_scan/)
-Scan the "real" infrastructure for vulnerabilities.
+### 6. ☁️ [Runtime Infrastructure Scan (live cloud)](workshop/runtime_infra_scan/)
+Scan a live AWS account for misconfigurations and drift that static IaC scans can't catch.
 
-### Bonus Tracks
-#### 🤖 [AI Security Analysis](workshop/ai_scan/)
-Leverage artificial intelligence for comprehensive security reviews and intelligent vulnerability detection.
+### 7. 🤖 [AI Security Analysis](workshop/ai_scan/) *(optional)*
+Leverage AI to perform comprehensive, context-aware security reviews of pull requests.
 
 
 ## 🚀 Getting Started

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -43,10 +43,48 @@ We suggest you follow the workshop in the following order, but feel free to jump
 6. [Runtime Infrastructure Scan](runtime_infra_scan/)
 7. [AI Security Analysis](ai_scan/)
 
+## Prerequisites
+
+Before you start:
+
+1. **Fork this repository** — you need write access to push, create branches, and configure secrets.
+
+   [![Fork this repo](https://img.shields.io/badge/Fork-this_repo-2ea44f?logo=github&style=for-the-badge)](https://github.com/unicrons/secure-pipeline-workshop/fork)
+
+2. **Clone your fork and create a working branch.** Keep `main` clean so you can compare your changes against the upstream and reset easily if something goes sideways.
+
+   ```bash
+   git clone git@github.com:<your-user>/secure-pipeline-workshop.git
+   cd secure-pipeline-workshop
+   git checkout -b workshop
+   ```
+
+3. **(Recommended) Enable GitHub Advanced Security on your fork** — some tools (Semgrep, Grype, Trivy IaC) upload SARIF and only show full findings in the *Code Scanning* tab. Without GHAS, their job logs look thin; each module's `Solutions` section tells you where to look instead.
+
+4. **Per-module secrets and variables** — most modules work out of the box. The ones that don't:
+
+   | Module | What you need | Where to get it |
+   |---|---|---|
+   | 2. Code Scan | `NVD_API_KEY` *(secret, optional but recommended for OWASP Dependency Check)* | [Request from NVD](https://nvd.nist.gov/developers/request-an-api-key) |
+   | 6. Runtime Infra Scan | `AWS_IAM_ROLE_ARN` *(secret)*, `AWS_REGION` + `AWS_IAM_ROLE_SESSION_DURATION` *(vars)* | IAM role with `SecurityAudit` + `ViewOnlyAccess` and a GitHub OIDC trust policy |
+
+   Configure them at `Settings → Secrets and variables → Actions` on your fork.
+
 ## Workshop flow
-To begin, fork this repository. Then, for each module:
-1. Read the README.md file.
-2. For each tool within that module, follow the instructions in the `workflow.yml` file.
-3. Push your changes and observe the results.
-4. Work to fix any issues for that step until you achieve a green pipeline ✅.
-5. Then, try a different tool (if available) or proceed to the next module.
+
+The pipeline runs through `pipeline-orchestrator.yml`, which calls each module's workflow at `.github/workflows/<module>-scan.yml`. Every module ships as a **placeholder job** that you replace with a real tool's job — this is the core mechanic of the workshop.
+
+For each module:
+
+1. **Read** the module's `README.md` for context (why, common issues, tools available).
+2. **Pick a tool** and open `workshop/<module>/<tool>/workflow.yml`. The header comments list any extra prerequisites for that tool.
+3. **Replace** the entire `jobs:` section of `.github/workflows/<module>-scan.yml` with the `jobs:` section from the tool's `workflow.yml`. Keep the file's `name:`, `on:`, `inputs:`, `secrets:`, and `outputs:` blocks intact.
+4. **Commit and push** to your fork. The orchestrator triggers automatically — follow it in the *Actions* tab.
+5. **Read the failure**: each module ships with a planted **bait** (a misconfiguration or vulnerable line) the scanner is meant to catch. The job log points at the file and line. If you get stuck, the module's `Solutions` section is your safety net.
+6. **Fix the bait** and push again until the job goes green ✅.
+7. **(Optional)** Try a second tool in the same module — it usually flags the same bait, so the existing fix clears it too.
+8. **Move on** to the next module.
+
+> ℹ️ **The orchestrator runs every module's job on every push.** Modules whose placeholder you haven't replaced stay green by design (the placeholder just echoes a message). Focus on the job for the module you're working on.
+
+> ℹ️ **Module 6 exception**: the runtime infra scan runs against a *live AWS account*, so there's no planted bait to fix. It's expected to pass green even when Prowler reports findings — see its `Solutions` section.


### PR DESCRIPTION
## Summary
Two related documentation improvements aimed at first-time visitors. They sit on the two top-level READMEs and complement each other (root = "what & why", `workshop/README.md` = "how").

### 1. Root `README.md` — clarify module index
- **"Introduction" out of the numbered list** — it's meta-content (CI/CD/CS, shift-left), not a learning module. Moved to a one-line pointer above the index: *"🐦‍🔥 New here? Start with the workshop introduction…"*
- **Modules 5 vs 6 disambiguated** — both used to read very similarly:
  - 5 → `Infrastructure as Code (IaC) Security Scan`
  - 6 → `Runtime Infrastructure Scan (live cloud)`
- **Duplicated 🔍 emoji fixed** — modules 1 and 6 both used the magnifying glass. Module 1 now uses 🛡️ and module 6 uses ☁️.
- **AI Scan promoted to module 7** — matches the index in `workshop/README.md` (which already lists it as 7) and removes the awkward "Bonus Tracks" header with a single item below it. Tagged `*(optional)*` to keep the "extra" framing.
- **Sharper descriptions** for modules 1, 2, 5, 6 — less acronym dump, more concrete examples (e.g. module 1 now mentions unpinned actions / excessive permissions instead of generic "scan pipelines for security misconfigurations").
- **Drop the `'real'` quotes** in module 6 description — they were unexplained and read as scare quotes.

### 2. `workshop/README.md` — explicit prerequisites and flow
- New **Prerequisites** section: fork badge, clone+branch command, GHAS recommendation, and a table of per-module secrets/variables (NVD_API_KEY, AWS role + vars).
- Rewritten **Workshop flow**:
  - Names `pipeline-orchestrator.yml` as the entry point.
  - Makes the placeholder-replace mechanic explicit (which file, which `jobs:` block to swap, what to keep intact).
  - Introduces the *bait* concept up front so learners don't think the repo is broken.
  - Documents two non-obvious behaviors as call-outs:
    - The orchestrator runs every module's job on every push; modules whose placeholder hasn't been replaced stay green by design.
    - **Module 6 exception**: runs against a live AWS account, no planted bait, expected to pass green.

## Why
Tested by re-reading both READMEs as a first-time visitor:

- The root index had small "wait, what?" moments (numbered "0. Introduction", repeating 🔍, IaC/runtime title overlap, lonely "Bonus Tracks" header) before reaching any actual content.
- `workshop/README.md` had the right sections but learners had to discover by themselves that the workflow.yml in each tool dir was meant to *replace* a placeholder, that some modules need extra secrets, and that module 6 has no bait. All implicit. This rewrite surfaces it before the friction.

## Test plan
- [ ] Render both READMEs on GitHub and read top-to-bottom as a first-time visitor
- [ ] Confirm all module links still resolve
- [ ] Verify the AI Scan section in the root flows naturally without the "Bonus Tracks" header
- [ ] Confirm the fork badge in `workshop/README.md` opens the GitHub fork dialog
- [ ] Verify the per-module secrets/variables table is accurate for the current snippets