### PR TITLE
UX overhaul: unblock self-paced runs, restructure READMEs, fix snippet bugs

### DIFF
--- a/.github/workflows/runtime-infra-scan.yml
+++ b/.github/workflows/runtime-infra-scan.yml
@@ -14,7 +14,7 @@ on:
     secrets:
       AWS_IAM_ROLE_ARN:
         description: "AWS IAM Role ARN for authentication"
-        required: true
+        required: false
     outputs:
       runtime-infra-scan-result:
         description: "Runtime infrastructure scan result"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Secure Pipeline Workshop
 
+> [!NOTE]
+> **Platform-agnostic principles, GitHub-Actions implementation.** This workshop runs on GitHub Actions for hands-on convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To run this on GitLab CI, Jenkins, CircleCI, etc., you'd translate the orchestration glue (workflow files, secrets, triggers) but keep everything else.
+
 Welcome to the "Secure Pipeline" workshop! This hands-on workshop teaches you how to build a comprehensive security-focused CI/CD pipeline with multiple layers of security scanning and best practices.
 
-## 🏗️ Workshop Structure
+> ⏱ **Estimated time:** 2–3 hours self-paced (~20 min per module). The workshop is **zero-install** — everything runs in GitHub Actions on your fork.
 
-The workshop is organized into different modules, each focusing on a specific aspect of pipeline security:
-
-### 📁 Repository Structure
+## 📁 Repository Structure
 
 ```
 ├── .github/workflows/               # GitHub Actions workflows
@@ -17,18 +18,18 @@ The workshop is organized into different modules, each focusing on a specific as
 
 ## 📚 Workshop Modules
 
-> 🐦‍🔥 New here? Start with the [workshop introduction](workshop/) for context on shift-left and CI/CD/CS.
+> 🐦‍🔥 New here? Start with the [workshop introduction](workshop/) for context on shift-left, CI/CD/CS, prerequisites, and how the workshop works.
 
 ### 1. 🛡️ [Pipeline Security Scan](workshop/pipeline_scan/)
 Detect insecure GitHub Actions patterns: unpinned actions, excessive permissions, untrusted authors.
 
-### 2. 🔬 [Code Security Analysis](workshop/code_scan/)
+### 2. 🔬 [Code Security Scan](workshop/code_scan/)
 Find vulnerabilities in your application code (SAST) and in its dependencies (SCA).
 
 ### 3. 🔐 [Secrets Scan](workshop/secrets_scan/)
 Detect and prevent exposure of credentials and sensitive information.
 
-### 4. 🐳 [Container Security Scanning](workshop/container_scan/)
+### 4. 🐳 [Container Security Scan](workshop/container_scan/)
 Scan Docker images for vulnerabilities and misconfigurations.
 
 ### 5. 🏗️ [Infrastructure as Code (IaC) Security Scan](workshop/iac_scan/)
@@ -39,49 +40,6 @@ Scan a live AWS account for misconfigurations and drift that static IaC scans ca
 
 ### 7. 🤖 [AI Security Analysis](workshop/ai_scan/) *(optional)*
 Leverage AI to perform comprehensive, context-aware security reviews of pull requests.
-
-
-## 🚀 Getting Started
-
-### Prerequisites
-- GitHub Account to fork the repository
-- Basic knowledge of CI/CD concepts
-- Familiarity with containers and cloud infrastructure concepts
-
-> [!TIP]
-> While this workshop uses GitHub Actions, most of the skills and best practices you learn can be applied to any CI/CD platform.
-
-### Workshop Flow
-1. **Fork this repository** to your GitHub account
-2. **Follow each module** in the workshop directory
-3. **Run the workflows** and observe the security findings
-4. **Learn to fix** the identified vulnerabilities
-5. **Implement security best practices**
-
-### Workshop Goal
-The idea of this workshop is to demonstrate how to build a "perfect" (secure and practical) CI/CD pipeline using open-source tools (OSS).
-
-**The goal is inspirational, not prescriptive.** We do not want you to copy these examples, but to understand the principles and identify the modular components you can adapt to implement in your own environment.
-
-### 🎓 Learning Outcomes
-
-By completing this workshop, you will:
-- Understand the importance of shift-left security
-- Learn the key stages of a secure pipeline:
-  - Pipeline Security
-  - Static and Dynamic Code Analysis
-  - Secrets Detection
-  - Container Security
-  - Infrastructure as Code (IaC) Security
-  - Runtime Infrastructure Security
-- Know relevant OSS tools for each stage
-- Grasp the principles needed to start building or improving your own secure CI/CD process
-
-### Out of Scope (What this workshop is NOT)
-- Deep dives into specific development workflows (e.g., Gitflow vs. Trunk-based)
-- Focus on a specific application technology stack (language/framework agnostic where possible)
-- A definitive statement on the "best" tools (alternatives will be mentioned for key steps)
-
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Secure Pipeline Workshop
 
-> [!NOTE]
-> **Platform-agnostic principles, GitHub-Actions implementation.** This workshop runs on GitHub Actions for hands-on convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To run this on GitLab CI, Jenkins, CircleCI, etc., you'd translate the orchestration glue (workflow files, secrets, triggers) but keep everything else.
-
 Welcome to the "Secure Pipeline" workshop! This hands-on workshop teaches you how to build a comprehensive security-focused CI/CD pipeline with multiple layers of security scanning and best practices.
 
-> ⏱ **Estimated time:** 2–3 hours self-paced (~20 min per module). The workshop is **zero-install** — everything runs in GitHub Actions on your fork.
+> ⏱ **Estimated time:** 2–3 hours self-paced (~20 min per module).
+
+> [!NOTE]
+> **Platform-agnostic principles:** This workshop runs on GitHub Actions for hands-on convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To run this on GitLab CI, Jenkins, CircleCI, etc., you'd translate the orchestration glue (workflow files, secrets, triggers) but keep everything else.
+
 
 ## 📁 Repository Structure
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,66 +1,14 @@
-# Infrastructure as Code
+# `infra/` — sample Terraform scanned by the workshop
 
-> [!CAUTION]
-> This infra folder is a simulation and has not been used in the actual workshop. It serves as a demonstration of security misconfigurations for educational purposes.
+This directory contains the Terraform resources that **Module 5: IaC Security
+Scan** runs Checkov and Trivy IaC against. It defines an ECS Fargate sample
+deployment with **one intentional misconfiguration** (the bait) for the
+scanners to catch.
 
-This directory contains Terraform configurations for deploying the workshop application infrastructure on AWS. The infrastructure is intentionally designed with various security misconfigurations to demonstrate IaC security scanning tools.
+> [!NOTE]
+> These files are **never applied locally** — the workshop is zero-install.
+> All scans run in GitHub Actions via `pipeline-orchestrator.yml`.
 
-## Infrastructure Components
-
-- **VPC** - Virtual Private Cloud with public and private subnets
-- **EC2** - Application server instance
-- **Security Groups** - Network access control
-- **Internet Gateway** - Internet connectivity
-
-## Security Issues (Intentional for Workshop)
-
-This Terraform configuration contains several security misconfigurations that will be detected during the workshop:
-
-1. **Overly Permissive Security Groups** - SSH access from 0.0.0.0/0
-2. **Unencrypted Resources** - EBS volumes without encryption
-3. **Exposed Outputs** - Sensitive information in outputs
-4. **Missing Security Features** - No IMDSv2 enforcement
-5. **Hardcoded Values** - Credentials in variables
-6. **No State Encryption** - Backend without encryption
-7. **Missing State Locking** - No DynamoDB state locking
-
-## Files
-
-- `main.tf` - Provider configuration and backend settings
-- `variables.tf` - Input variables (with security issues)
-- `ec2.tf` - EC2 and networking resources
-- `outputs.tf` - Output values (with sensitive data exposure)
-
-## Usage
-
-```bash
-# Initialize Terraform
-terraform init
-
-# Validate configuration
-terraform validate
-
-# Plan deployment
-terraform plan
-
-# Apply configuration
-terraform apply
-```
-
-## Workshop Steps
-
-During the workshop, various IaC security scanning tools will identify these issues:
-
-1. **Checkov** - Policy as code scanner
-2. **TFSec** - Terraform security scanner
-3. **Terrascan** - Infrastructure security scanner
-4. **Semgrep** - SAST for IaC
-
-## Security Best Practices (For Reference)
-
-- Enable encryption for all resources
-- Use least privilege access principles
-- Implement proper state management
-- Use secure backends with encryption
-- Avoid hardcoded credentials
-- Enable security monitoring and logging
+- 📘 [Module 5 — IaC Security Scan](../workshop/iac_scan/) — context, tools, instructions
+- 🐛 [The intentional bait + fix](../workshop/iac_scan/#solutions) — spoilers, open only when stuck
+- 🛰 [Module 6 — Runtime Infrastructure Scan](../workshop/runtime_infra_scan/) — what would scan this in production

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -1,8 +1,33 @@
 # Perfect Pipeline Introduction
 
+> ⏱ **Estimated time:** 2–3 hours self-paced (~20 min per module).
+
 This workshop is designed to help you understand the importance of shift-left security and how to implement comprehensive security scanning in your pipeline.
 
 All of this without forgetting the human factor, as the final objective is not blind security but enabling your users (or yourself) to build secure software effectively.
+
+## Workshop Goal
+
+The idea of this workshop is to demonstrate how to build a "perfect" (secure and practical) CI/CD pipeline using open-source tools (OSS).
+
+**The goal is inspirational, not prescriptive.** We do not want you to copy these examples, but to understand the principles and identify the modular components you can adapt to implement in your own environment.
+
+> [!NOTE]
+> **Platform-agnostic principles, GitHub-Actions implementation.** The workshop runs on GitHub Actions for convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To take this to GitLab CI, Jenkins, CircleCI, etc., translate the orchestration glue (workflow files, secrets, triggers) and keep everything else.
+
+## 🎓 Learning Outcomes
+
+By completing this workshop, you will:
+- Understand the importance of shift-left security
+- Learn the key stages of a secure pipeline:
+  - Pipeline Security
+  - Static and Dynamic Code Analysis
+  - Secrets Detection
+  - Container Security
+  - Infrastructure as Code (IaC) Security
+  - Runtime Infrastructure Security
+- Know relevant OSS tools for each stage
+- Grasp the principles needed to start building or improving your own secure CI/CD process
 
 Let's start with some important concepts:
 
@@ -31,14 +56,20 @@ Shift-left security is a security practice that aims to move security checks and
 <p align="center"><em>Based on the image from https://devopedia.org/shift-left</em></p>
 </p>
 
+## How the workshop works
+
+Each module ships as a **placeholder job** in `.github/workflows/`. You swap it for a real tool's job (provided under `workshop/<module>/<tool>/`), push, and watch the orchestrator catch a planted misconfiguration (the **bait**). Fix it, push again, green ✅. Move to the next module.
+
+> Set up your fork in **Prerequisites** below, then jump to [**Working through a module**](#working-through-a-module) for the full step-by-step.
 
 ## Workshop Index
+
 We suggest you follow the workshop in the following order, but feel free to jump around and explore the different modules.
 
 1. [Pipeline Security Scan](pipeline_scan/)
-2. [Code Security Analysis](code_scan/)
+2. [Code Security Scan](code_scan/)
 3. [Secrets Scan](secrets_scan/)
-4. [Container Security Scanning](container_scan/)
+4. [Container Security Scan](container_scan/)
 5. [Infrastructure as Code Security Scan](iac_scan/)
 6. [Runtime Infrastructure Scan](runtime_infra_scan/)
 7. [AI Security Analysis](ai_scan/)
@@ -51,15 +82,12 @@ Before you start:
 
    [![Fork this repo](https://img.shields.io/badge/Fork-this_repo-2ea44f?logo=github&style=for-the-badge)](https://github.com/unicrons/secure-pipeline-workshop/fork)
 
-2. **Clone your fork and create a working branch.** Keep `main` clean so you can compare your changes against the upstream and reset easily if something goes sideways.
+2. **Set up your working branch.**
+   On any page of **your fork**, press `.` (or change `github.com` → `github.dev` in the URL) to open a full VS Code editor in the browser. Use the branch picker (bottom-left) → create `workshop` off `main`. You're ready to edit YAMLs, commit and push from the Source Control panel. Keep `main` clean so you can compare your changes against the upstream and reset easily if something goes sideways.
 
-   ```bash
-   git clone git@github.com:<your-user>/secure-pipeline-workshop.git
-   cd secure-pipeline-workshop
-   git checkout -b workshop
-   ```
+   > Prefer your own editor? `git clone https://github.com/<your-user>/secure-pipeline-workshop.git && cd secure-pipeline-workshop && git checkout -b workshop`. Everything else applies the same way.
 
-3. **(Recommended) Enable GitHub Advanced Security on your fork** — some tools (Semgrep, Grype, Trivy IaC) upload SARIF and only show full findings in the *Code Scanning* tab. Without GHAS, their job logs look thin; each module's `Solutions` section tells you where to look instead.
+3. **(Optional) Enable GitHub Advanced Security on your fork** — some tools (Semgrep, Grype, Trivy IaC) upload SARIF for the *Code Scanning* tab. The job log already shows full findings (rule, message, file, line) regardless — GHAS just adds a richer UI on top.
 
 4. **Per-module secrets and variables** — most modules work out of the box. The ones that don't:
 
@@ -70,21 +98,26 @@ Before you start:
 
    Configure them at `Settings → Secrets and variables → Actions` on your fork.
 
-## Workshop flow
-
-The pipeline runs through `pipeline-orchestrator.yml`, which calls each module's workflow at `.github/workflows/<module>-scan.yml`. Every module ships as a **placeholder job** that you replace with a real tool's job — this is the core mechanic of the workshop.
+## Working through a module
 
 For each module:
 
 1. **Read** the module's `README.md` for context (why, common issues, tools available).
 2. **Pick a tool** and open `workshop/<module>/<tool>/workflow.yml`. The header comments list any extra prerequisites for that tool.
 3. **Replace** the entire `jobs:` section of `.github/workflows/<module>-scan.yml` with the `jobs:` section from the tool's `workflow.yml`. Keep the file's `name:`, `on:`, `inputs:`, `secrets:`, and `outputs:` blocks intact.
-4. **Commit and push** to your fork. The orchestrator triggers automatically — follow it in the *Actions* tab.
-5. **Read the failure**: each module ships with a planted **bait** (a misconfiguration or vulnerable line) the scanner is meant to catch. The job log points at the file and line. If you get stuck, the module's `Solutions` section is your safety net.
-6. **Fix the bait** and push again until the job goes green ✅.
-7. **(Optional)** Try a second tool in the same module — it usually flags the same bait, so the existing fix clears it too.
-8. **Move on** to the next module.
+4. **Commit and push** to your `workshop` branch.
+5. **Open a Pull Request** from `workshop` → your fork's `main`. GitHub shows a *"Compare & pull request"* banner right after the push — one click. The orchestrator runs as PR checks, so you can watch the whole pipeline directly from the PR's *Checks* tab without leaving the page. Every additional push to `workshop` re-runs the checks on the same PR (no need to reopen anything).
+6. **Read the failure**: each module ships with a planted **bait** (a misconfiguration or vulnerable line) the scanner is meant to catch. The job log points at the file and line. If you get stuck, the module's `Solutions` section is your safety net.
+7. **Fix the bait** and push again until the job goes green ✅.
+8. **(Optional)** Try a second tool in the same module — it usually flags the same bait, so the existing fix clears it too.
+9. **Move on** to the next module.
 
 > ℹ️ **The orchestrator runs every module's job on every push.** Modules whose placeholder you haven't replaced stay green by design (the placeholder just echoes a message). Focus on the job for the module you're working on.
 
-> ℹ️ **Module 6 exception**: the runtime infra scan runs against a *live AWS account*, so there's no planted bait to fix. It's expected to pass green even when Prowler reports findings — see its `Solutions` section.
+> ℹ️ **Module 6 exception**: the runtime infra scan runs against a *live AWS account*, so there's no planted bait to fix. It's expected to pass green even when Prowler reports findings — see its `Running this module` section.
+
+## Out of Scope (What this workshop is NOT)
+
+- Deep dives into specific development workflows (e.g., Gitflow vs. Trunk-based)
+- Focus on a specific application technology stack (language/framework agnostic where possible)
+- A definitive statement on the "best" tools (alternatives will be mentioned for key steps)

--- a/workshop/README.md
+++ b/workshop/README.md
@@ -13,7 +13,7 @@ The idea of this workshop is to demonstrate how to build a "perfect" (secure and
 **The goal is inspirational, not prescriptive.** We do not want you to copy these examples, but to understand the principles and identify the modular components you can adapt to implement in your own environment.
 
 > [!NOTE]
-> **Platform-agnostic principles, GitHub-Actions implementation.** The workshop runs on GitHub Actions for convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To take this to GitLab CI, Jenkins, CircleCI, etc., translate the orchestration glue (workflow files, secrets, triggers) and keep everything else.
+> **Platform-agnostic principles:* The workshop runs on GitHub Actions for convenience, but the **tools** (Semgrep, Trivy, Checkov, Prowler…) and **patterns** (shift-left, scan-then-gate, multi-layer pipeline) are universal. To take this to GitLab CI, Jenkins, CircleCI, etc., translate the orchestration glue (workflow files, secrets, triggers) and keep everything else.
 
 ## 🎓 Learning Outcomes
 

--- a/workshop/code_scan/README.md
+++ b/workshop/code_scan/README.md
@@ -1,4 +1,17 @@
-# Code Security Analysis (SAST/SCA)
+# Code Security Scan (SAST/SCA)
+
+> ⏱ ~25 min (SAST + SCA) · 📍 Module 2 of 7
+>
+> [1](../pipeline_scan/) ▸ **2** ▸ [3](../secrets_scan/) ▸ [4](../container_scan/) ▸ [5](../iac_scan/) ▸ [6](../runtime_infra_scan/) ▸ [7](../ai_scan/)
+
+> [!IMPORTANT]
+> **This module is the only one with two placeholders.** `.github/workflows/code-scan.yml`
+> ships with both a `sast-scan` and an `sca-scan` placeholder, because Code Scan covers
+> two complementary techniques. You can:
+>
+> - **Pick one** (replace the entire `jobs:` block with a single tool's job — quickest), or
+> - **Pick one of each** (paste both a SAST tool's job and an SCA tool's job into the same
+>   `jobs:` block, making sure each job has a unique key — full coverage).
 
 This workshop module covers Static Application Security Testing (SAST) and Software Composition Analysis (SCA) to identify security vulnerabilities in application code and dependencies.
 
@@ -68,6 +81,14 @@ By the end of this module, you will:
 - [ ] False positive management
 - [ ] Security metrics tracking
 
+## References
+
+- [OWASP Top Ten](https://owasp.org/www-project-top-ten/) — the canonical list of the most critical web application security risks; most SAST rule packs map back to it.
+- [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) — concrete requirements you can audit your code against.
+- [GitHub: About code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning) — how SARIF uploads surface in the *Security → Code scanning* tab.
+- [OSV.dev](https://osv.dev/) — the vulnerability database that powers `osv-scanner`; useful for manually checking a single package.
+- [Snyk: SAST vs DAST vs SCA](https://snyk.io/learn/application-security/sast-vs-dast-vs-sca/) — quick comparison of the three flavours of code/dependency analysis.
+
 ## Solutions (spoilers — open only when stuck)
 
 > The bait for this module lives in two places: a vulnerable code pattern in `code/src/simple-app.js` (SAST) and a known-vulnerable dependency in `code/package.json` (SCA). The CI failures are intentional.
@@ -117,7 +138,7 @@ if (filePath) {
 <details>
 <summary><b>Semgrep (SAST)</b> — <code>javascript.lang.security.audit.detect-child-process</code> at <code>code/src/simple-app.js:42</code></summary>
 
-**Reading the output**: Semgrep's job log only prints `Findings: 1 (1 blocking)` — no rule ID, no file/line. To see what failed, either open the GitHub Code Scanning tab (if your fork has GHAS) or download `semgrep-results.sarif` (you may want to add `actions/upload-artifact` to the snippet for this — it's missing by default).
+**Reading the output**: the snippet's `Summarize findings` step parses the SARIF and prints `ruleId | message | path:line` directly to the job log — no GHAS required. If your fork has GHAS enabled, the SARIF is also uploaded to the *Code Scanning* tab for a richer UI.
 
 **Same root cause as CodeQL**: the `exec(\`cat "${filePath}"\`, …)` line.
 

--- a/workshop/code_scan/sca/dependency_check/workflow.yml
+++ b/workshop/code_scan/sca/dependency_check/workflow.yml
@@ -30,10 +30,31 @@ jobs:
         with:
           project: 'code'
           path: './code'
-          format: 'HTML'
+          format: 'ALL'
           args: >
             --failOnCVSS 7
             --enableRetired
+
+      - name: Summarize findings
+        if: always() && hashFiles('reports/dependency-check-report.sarif') != ''
+        run: |
+          SARIF=reports/dependency-check-report.sarif
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No vulnerabilities found"
+          else
+            echo "❌ Found $COUNT Dependency Check finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && hashFiles('reports/dependency-check-report.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: reports/dependency-check-report.sarif
+          category: dependency-check-sca
 
       - name: Set scan result
         id: scan-result
@@ -41,14 +62,14 @@ jobs:
         run: |
           if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ Code scan passed - no critical vulnerabilities found"
+            echo "✅ Code scan passed — no critical vulnerabilities found"
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ Code scan failed - vulnerabilities detected"
+            echo "❌ Code scan failed — vulnerabilities detected"
             exit 1
           fi
 
-      - name: Upload scan report
+      - name: Upload HTML report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/workshop/container_scan/README.md
+++ b/workshop/container_scan/README.md
@@ -1,4 +1,8 @@
-# Container Security Scanning
+# Container Security Scan
+
+> ⏱ ~15 min · 📍 Module 4 of 7
+>
+> [1](../pipeline_scan/) ▸ [2](../code_scan/) ▸ [3](../secrets_scan/) ▸ **4** ▸ [5](../iac_scan/) ▸ [6](../runtime_infra_scan/) ▸ [7](../ai_scan/)
 
 This workshop module covers container security scanning to identify vulnerabilities in container images and configurations.
 
@@ -35,7 +39,7 @@ By the end of this module, you will:
 - Understand container security risks
 - Learn to scan images for vulnerabilities
 - Understand supply chain security for containers
-- [🔜] Identify Dockerfile security best practices
+- Identify Dockerfile security best practices
 
 > [!TIP]
 > **A clean scan can take more than one fix.** Bumping the base image
@@ -92,7 +96,7 @@ By the end of this module, you will:
 <details>
 <summary><b>Grype</b> — same root cause, terser output</summary>
 
-**What Grype reports**: a single line — `[…] ERROR discovered vulnerabilities at or above the severity threshold` — plus a helpful warning: `188 packages from EOL distro "alpine 3.19.4"`. The actual CVE list is uploaded as SARIF to the GitHub Code Scanning tab; if your fork doesn't have GHAS, the run page shows nothing actionable. Two snippet improvements help: switch `output-format: sarif` to `table` for the workshop, or upload the SARIF as an `actions/upload-artifact`.
+**What Grype reports**: the `Summarize findings` step parses the SARIF and prints each CVE as `ruleId | message | path:line` to the job log — plus a helpful warning: `188 packages from EOL distro "alpine 3.19.4"`. The full SARIF is also uploaded to the GitHub *Code Scanning* tab if your fork has GHAS enabled.
 
 **Same root cause as Trivy**: EOL alpine base.
 

--- a/workshop/iac_scan/README.md
+++ b/workshop/iac_scan/README.md
@@ -1,4 +1,8 @@
-# Infrastructure as Code (IaC) Security Scanning
+# Infrastructure as Code (IaC) Security Scan
+
+> ⏱ ~15 min · 📍 Module 5 of 7
+>
+> [1](../pipeline_scan/) ▸ [2](../code_scan/) ▸ [3](../secrets_scan/) ▸ [4](../container_scan/) ▸ **5** ▸ [6](../runtime_infra_scan/) ▸ [7](../ai_scan/)
 
 This workshop module focuses on scanning Infrastructure as Code (IaC) configurations to identify security misconfigurations before infrastructure deployment.
 
@@ -168,10 +172,7 @@ By the end of this module, you will:
 
 **What Trivy IaC flagged**: same ingress rule (port 22 from `0.0.0.0/0`). Trivy's rule ID is `AVD-AWS-0107`.
 
-**Reading the output**: the snippet is configured for SARIF-only — the job log shows `Running Trivy with options: trivy config infra/` followed by `Successfully uploaded results` with **no rule, no file, no line**. To see the finding, either:
-- read the GitHub Code Scanning tab (requires GHAS),
-- switch the snippet's `format` from `sarif` to `table` (sacrifices the GHAS upload), or
-- add an `actions/upload-artifact` step for `trivy-results.sarif` so you can download it.
+**Reading the output**: the snippet's `Summarize findings` step parses the SARIF and prints `ruleId | message | path:line` directly to the job log — no GHAS required. The SARIF is also uploaded to the GitHub *Code Scanning* tab if your fork has GHAS enabled.
 
 **Fix** — identical to the Checkov fix above.
 

--- a/workshop/pipeline_scan/README.md
+++ b/workshop/pipeline_scan/README.md
@@ -1,5 +1,9 @@
 # Pipeline Security Scan
 
+> ⏱ ~15 min · 📍 Module 1 of 7
+>
+> **1** ▸ [2](../code_scan/) ▸ [3](../secrets_scan/) ▸ [4](../container_scan/) ▸ [5](../iac_scan/) ▸ [6](../runtime_infra_scan/) ▸ [7](../ai_scan/)
+
 This workshop module focuses on scanning the pipeline configuration itself for security vulnerabilities and misconfigurations.
 
 ## Why is Pipeline Security Important?

--- a/workshop/runtime_infra_scan/README.md
+++ b/workshop/runtime_infra_scan/README.md
@@ -1,5 +1,14 @@
 # Runtime Infrastructure Scan
 
+> ⏱ ~10 min (read-only) / ~25 min (live AWS) · 📍 Module 6 of 7
+>
+> [1](../pipeline_scan/) ▸ [2](../code_scan/) ▸ [3](../secrets_scan/) ▸ [4](../container_scan/) ▸ [5](../iac_scan/) ▸ **6** ▸ [7](../ai_scan/)
+
+> [!IMPORTANT]
+> This module needs **a live AWS account** (IAM role + GitHub OIDC trust). Without it,
+> leave the placeholder as-is — the rest of the workshop works fine. To enable it,
+> see [Running this module](#running-this-module) below.
+
 This workshop module focuses on scanning the deployed (runtime) infrastructure for vulnerabilities and misconfigurations that may not be detectable through static analysis of code or configuration files.
 
 ## Why is Runtime Infrastructure Scanning Important?
@@ -64,7 +73,7 @@ By the end of this module, you will:
 - [ ] Monitoring and logging enabled for all critical resources
 - [ ] Regular runtime scans scheduled and reviewed
 
-## Solutions (spoilers — open only when stuck)
+## Running this module
 
 > Unlike the other modules, this one has **no planted bait** to fix. Runtime scans target a *live* AWS account, so the findings depend entirely on whose infrastructure the job assumes into. During the workshop the role points at the maintainers' sandbox account, where you have no permissions to remediate anything — the job is expected to pass green even if Prowler reports findings (note the `-z` flag in the snippet, which suppresses the failing exit code on findings so the pipeline doesn't block on issues you can't fix).
 
@@ -76,6 +85,17 @@ By the end of this module, you will:
 **Why nothing is failing**: `prowler aws ... -z` (the "zero exit code" flag) is intentional here. Without it, *any* finding would fail the job, and you'd be staring at issues in someone else's account with no way to fix them. The point of this step in the workshop is to **wire the integration** (OIDC auth, role assumption, artifact upload), not to remediate.
 
 **Reading the report**: open `prowler-html-report/*.html` and look for high-severity items in `iam` (overly permissive policies, unused credentials, root usage) and `s3` (public buckets, unencrypted storage, missing logging). These are the categories you'd triage first on a real account.
+
+</details>
+
+<details>
+<summary><b>Steampipe + Powerpipe</b> — what to expect during the workshop</summary>
+
+**What you'll see**: the snippet starts a local `steampipe service`, then runs the [`steampipe-mod-aws-compliance`](https://github.com/turbot/steampipe-mod-aws-compliance) `cis_v150` benchmark via Powerpipe against the assumed AWS role. The HTML report is uploaded as the `powerpipe-html-report` artifact — download it from the run summary to browse the CIS v1.5.0 benchmark results.
+
+**Why pick Steampipe over Prowler**: Steampipe exposes cloud resources as **SQL tables** (`select * from aws_iam_user where mfa_enabled = false;`), so you can write ad-hoc compliance queries instead of relying on canned check IDs. The Powerpipe layer adds dashboards, benchmarks (CIS, NIST, PCI…), and HTML/CSV export for any of them. Useful when you need to investigate specific drift patterns rather than run a fixed audit.
+
+**Reading the report**: open `aws_compliance.benchmark.cis_v150.*.html` and follow the failed controls — each one links back to the underlying SQL query, which you can re-run interactively in a local `steampipe query` session for deeper investigation.
 
 </details>
 

--- a/workshop/runtime_infra_scan/steampipe/workflow.yml
+++ b/workshop/runtime_infra_scan/steampipe/workflow.yml
@@ -61,6 +61,7 @@ jobs:
           steampipe service start
 
       - name: Run specific AWS Compliance benchmarks
+        id: powerpipe
         uses: turbot/powerpipe-action-check@0b905d17e8b6970bc39bcd347c053992bd8770de # v1.0.1
         with:
           mod-url: https://github.com/turbot/steampipe-mod-aws-compliance
@@ -82,8 +83,8 @@ jobs:
         run: |
           if [ "${{ steps.powerpipe.outcome }}" == "success" ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ Runtime infrastructure scan passed - no critical issues found"
+            echo "✅ Runtime infrastructure scan passed — no critical issues found"
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ Runtime infrastructure scan failed - security issues detected"
+            echo "❌ Runtime infrastructure scan failed — security issues detected"
           fi

--- a/workshop/secrets_scan/README.md
+++ b/workshop/secrets_scan/README.md
@@ -1,5 +1,9 @@
 # Secrets Scan
 
+> ⏱ ~15 min · 📍 Module 3 of 7
+>
+> [1](../pipeline_scan/) ▸ [2](../code_scan/) ▸ **3** ▸ [4](../container_scan/) ▸ [5](../iac_scan/) ▸ [6](../runtime_infra_scan/) ▸ [7](../ai_scan/)
+
 This workshop module focuses on identifying and preventing the exposure of sensitive credentials, API keys, and other secrets in source code, configuration files, and git history.
 
 ## Why is Secrets Scan Important?


### PR DESCRIPTION
## Summary

Comprehensive UX overhaul from a structured review of the workshop. Three buckets:

- **Blockers fixed** that prevented self-paced runs from working (`infra/README.md` contradicting the actual IaC module; runtime scan hard-failing without AWS; the orchestrator trigger was correct, but the README never told users to open a PR after pushing).
- **Restructure of root + workshop READMEs**: root becomes a landing page, `workshop/` becomes the canonical manual, browser-only `github.dev` path added as default, "How the workshop works" mental model promoted to top.
- **Per-module consistency**: titles unified to "Scan", per-module breadcrumb + time estimate header, section ordering aligned, obsolete GHAS warnings cleaned (the existing `Summarize findings` step makes them moot).

Plus 2 functional bugs in tool snippets (Steampipe always reporting false fail; Dependency Check missing the `Summarize findings` step that every other SAST/SCA tool has).

Module 7 (AI) is parked on a separate branch (`ai-rethink`) for an opinionated 2026 redesign — not part of this PR.

## Commits

1. `fix(blockers)` — `infra/README.md` rewritten as a stub, `runtime-infra-scan.yml` secret marked optional.
2. `docs(readmes)` — root + `workshop/README.md` restructure, github.dev path, open-PR step added.
3. `docs(modules)` — vocabulary unified to "Scan", breadcrumbs/time per module, section alignment, obsolete GHAS notes removed, module-specific README fixes (`[🔜]` placeholder, dual-placeholder callout, IMPORTANT for module 6, Steampipe Solutions content).
4. `fix(snippets)` — Steampipe `id: powerpipe` + Dependency Check `Summarize findings`.

## Test plan

- [ ] Fork upstream, push to a `workshop` branch, open PR — orchestrator runs all 7 module placeholders green out of the box.
- [ ] Replace each module's placeholder with a snippet:
  - [ ] Each scan triggers the planted bait, applying the documented fix clears it.
  - [ ] Job logs print readable findings (rule / message / file:line) without GHAS for every tool.
- [ ] Steampipe (module 6, live mode) correctly reports success/failure (was always reporting false fail).
- [ ] Dependency Check (module 2) prints the `Summarize findings` block in the job log.
- [ ] github.dev path: press `.` on the fork, create `workshop` branch, edit a YAML, commit + push from Source Control panel — full flow works without a local clone.