### PR TITLE
feat(iac-scan): wire Checkov SARIF to GitHub Code Scanning

### DIFF
--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -31,12 +31,11 @@ jobs:
           framework: terraform
           quiet: true
           output_format: sarif
-          output_file_path: checkov-results
 
       - name: Summarize findings
-        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        if: always() && hashFiles('results.sarif') != ''
         run: |
-          SARIF=checkov-results/results_sarif.sarif
+          SARIF=results.sarif
           COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
           if [ "${COUNT:-0}" -eq 0 ]; then
             echo "✅ No security alerts"
@@ -48,10 +47,10 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        if: always() && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
         with:
-          sarif_file: checkov-results/results_sarif.sarif
+          sarif_file: results.sarif
           category: checkov-iac
 
       - name: Set scan result

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -8,65 +8,18 @@ on:
         value: ${{ jobs.iac-scan.outputs.result }}
 
 jobs:
+  # 🚧 REPLACE THIS ENTIRE 'jobs:' SECTION WITH WORKSHOP CONTENT! 🚧
+  # Copy from: workshop/iac_scan/{tool}/workflow.yml
+
   iac-scan:
-    name: IAC Scan with Checkov
+    name: "🚧 IAC Scan - Workshop Placeholder"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     outputs:
-      result: ${{ steps.scan-result.outputs.result }}
+      result: ${{ steps.placeholder.outputs.result }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run Checkov IAC scanner
-        id: scan-tool
-        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
-        with:
-          directory: infra/
-          framework: terraform
-          quiet: true
-          output_format: sarif
-
-      - name: Summarize findings
-        if: always() && hashFiles('results.sarif') != ''
+      - name: Workshop Placeholder
+        id: placeholder
         run: |
-          SARIF=results.sarif
-          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
-          if [ "${COUNT:-0}" -eq 0 ]; then
-            echo "✅ No security alerts"
-          else
-            echo "❌ Found $COUNT Checkov finding(s):"
-            jq -r '.runs[].results[] |
-              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
-              "$SARIF"
-          fi
-
-      - name: Upload SARIF to GitHub Code Scanning
-        if: always() && hashFiles('results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
-        with:
-          sarif_file: results.sarif
-          category: checkov-iac
-
-      - name: Set scan result
-        id: scan-result
-        if: always()
-        run: |
-          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
-            echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ IAC scan passed - no security issues found"
-          else
-            echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ IAC scan failed - security issues detected"
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
-            else
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
-            fi
-            exit 1
-          fi
+          echo "🚧 Replace this job with content from workshop/iac_scan/{tool}/workflow.yml!"
+          echo "This will implement: Infrastructure security scan with your chosen tool"
+          echo "result=workshop-placeholder" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/iac-scan.yml
+++ b/.github/workflows/iac-scan.yml
@@ -8,18 +8,66 @@ on:
         value: ${{ jobs.iac-scan.outputs.result }}
 
 jobs:
-  # 🚧 REPLACE THIS ENTIRE 'jobs:' SECTION WITH WORKSHOP CONTENT! 🚧
-  # Copy from: workshop/iac_scan/{tool}/workflow.yml
-
   iac-scan:
-    name: "🚧 IAC Scan - Workshop Placeholder"
+    name: IAC Scan with Checkov
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     outputs:
-      result: ${{ steps.placeholder.outputs.result }}
+      result: ${{ steps.scan-result.outputs.result }}
     steps:
-      - name: Workshop Placeholder
-        id: placeholder
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Checkov IAC scanner
+        id: scan-tool
+        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
+        with:
+          directory: infra/
+          framework: terraform
+          quiet: true
+          output_format: sarif
+          output_file_path: checkov-results
+
+      - name: Summarize findings
+        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
         run: |
-          echo "🚧 Replace this job with content from workshop/iac_scan/{tool}/workflow.yml!"
-          echo "This will implement: Infrastructure security scan with your chosen tool"
-          echo "result=workshop-placeholder" >> "$GITHUB_OUTPUT"
+          SARIF=checkov-results/results_sarif.sarif
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Checkov finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: checkov-results/results_sarif.sarif
+          category: checkov-iac
+
+      - name: Set scan result
+        id: scan-result
+        if: always()
+        run: |
+          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "✅ IAC scan passed - no security issues found"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "❌ IAC scan failed - security issues detected"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
+            exit 1
+          fi

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -30,6 +30,10 @@ jobs:
   iac-scan:
     needs: pipeline-scan
     uses: ./.github/workflows/iac-scan.yml
+    permissions:
+      security-events: write
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
 
   ai-review:
     needs: pipeline-scan

--- a/workshop/iac_scan/checkov/workflow.yml
+++ b/workshop/iac_scan/checkov/workflow.yml
@@ -37,12 +37,11 @@ jobs:
           framework: terraform
           quiet: true
           output_format: sarif
-          output_file_path: checkov-results
 
       - name: Summarize findings
-        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        if: always() && hashFiles('results.sarif') != ''
         run: |
-          SARIF=checkov-results/results_sarif.sarif
+          SARIF=results.sarif
           COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
           if [ "${COUNT:-0}" -eq 0 ]; then
             echo "✅ No security alerts"
@@ -54,10 +53,10 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        if: always() && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
         with:
-          sarif_file: checkov-results/results_sarif.sarif
+          sarif_file: results.sarif
           category: checkov-iac
 
       - name: Set scan result

--- a/workshop/iac_scan/checkov/workflow.yml
+++ b/workshop/iac_scan/checkov/workflow.yml
@@ -38,10 +38,17 @@ jobs:
           quiet: true
           output_format: sarif
 
-      - name: Summarize findings
+      - name: Normalize SARIF paths to repo root
         if: always() && hashFiles('results.sarif') != ''
+        # Checkov emits paths relative to --directory; rewrite to repo-root so GHAS can map findings to the PR diff.
         run: |
-          SARIF=results.sarif
+          jq '(.runs[].results[].locations[].physicalLocation.artifactLocation.uri) |= "infra/" + .' \
+            results.sarif > checkov.sarif
+
+      - name: Summarize findings
+        if: always() && hashFiles('checkov.sarif') != ''
+        run: |
+          SARIF=checkov.sarif
           COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
           if [ "${COUNT:-0}" -eq 0 ]; then
             echo "✅ No security alerts"
@@ -53,10 +60,10 @@ jobs:
           fi
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always() && hashFiles('results.sarif') != ''
+        if: always() && hashFiles('checkov.sarif') != ''
         uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
         with:
-          sarif_file: results.sarif
+          sarif_file: checkov.sarif
           category: checkov-iac
 
       - name: Set scan result

--- a/workshop/iac_scan/checkov/workflow.yml
+++ b/workshop/iac_scan/checkov/workflow.yml
@@ -9,13 +9,17 @@
 # 1. Copy this entire job definition into .github/workflows/iac-scan.yml
 # 2. Replace the current jobs: definition with this one
 # 3. The job will automatically scan all terraform files in infra/
-# 4. The scan will fail if any security issues are found
+# 4. Results will be uploaded to GitHub Advanced Security (SARIF format)
+# 5. The scan will fail if any security issues are found
 # =============================================================================
 
 jobs:
   iac-scan:
     name: IAC Scan with Checkov
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     outputs:
       result: ${{ steps.scan-result.outputs.result }}
     steps:
@@ -32,6 +36,29 @@ jobs:
           directory: infra/
           framework: terraform
           quiet: true
+          output_format: sarif
+          output_file_path: checkov-results
+
+      - name: Summarize findings
+        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        run: |
+          SARIF=checkov-results/results_sarif.sarif
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Checkov finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && hashFiles('checkov-results/results_sarif.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: checkov-results/results_sarif.sarif
+          category: checkov-iac
 
       - name: Set scan result
         id: scan-result
@@ -43,5 +70,10 @@ jobs:
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ IAC scan failed - security issues detected"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Checkov now generates SARIF and uploads it to GitHub Code Scanning under category `checkov-iac` so findings appear inline in PRs as the `github-advanced-security` bot and in the Security tab.
- Adds a `Summarize findings` step matching the existing pattern in Trivy IaC, Dependency-Check, CodeQL, etc., guaranteeing a readable findings list in the job log even on repos without GHAS enabled.
- Grants `security-events: write` to the orchestrator's `iac-scan` caller job so the reusable workflow can upload SARIF.
- Temporarily replaces the `iac-scan` placeholder with the Checkov job to actually exercise the workflow on this PR.

## Test plan
- [ ] Workflow `Pipeline Orchestrator / iac-scan` runs and the `Run Checkov IAC scanner` step exits with findings.
- [ ] `Summarize findings` step prints the `❌ Found N Checkov finding(s):` list.
- [ ] `Upload SARIF to GitHub Code Scanning` step succeeds.
- [ ] PR shows inline review comments from the `github-advanced-security` bot on `infra/*.tf`.
- [ ] `Checks` tab shows a `Code scanning / checkov-iac` entry.
- [ ] `Security → Code scanning` lists the alerts under the `checkov-iac` category.