### PR TITLE
feat(secrets-scan): wire Gitleaks SARIF to GitHub Code Scanning

### DIFF
--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      actions: read
 
   code-scan:
     needs: pipeline-scan
@@ -20,6 +21,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      actions: read
 
   secrets-scan:
     needs: pipeline-scan
@@ -27,6 +29,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      actions: read
 
   iac-scan:
     needs: pipeline-scan
@@ -46,6 +49,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     uses: ./.github/workflows/build-and-container-scan.yml
 
   deploy-infrastructure:

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -26,6 +26,10 @@ jobs:
   secrets-scan:
     needs: pipeline-scan
     uses: ./.github/workflows/secrets-scan.yml
+    permissions:
+      security-events: write
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
 
   iac-scan:
     needs: pipeline-scan

--- a/.github/workflows/pipeline-orchestrator.yml
+++ b/.github/workflows/pipeline-orchestrator.yml
@@ -12,24 +12,21 @@ jobs:
     uses: ./.github/workflows/pipeline-scan.yml
     permissions:
       security-events: write
-      contents: read # only needed for private repos
-      actions: read # only needed for private repos
+      contents: read
 
   code-scan:
     needs: pipeline-scan
     uses: ./.github/workflows/code-scan.yml
     permissions:
       security-events: write
-      contents: read # only needed for private repos
-      actions: read # only needed for private repos
+      contents: read
 
   secrets-scan:
     needs: pipeline-scan
     uses: ./.github/workflows/secrets-scan.yml
     permissions:
       security-events: write
-      contents: read # only needed for private repos
-      actions: read # only needed for private repos
+      contents: read
 
   iac-scan:
     needs: pipeline-scan
@@ -49,7 +46,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      actions: read
     uses: ./.github/workflows/build-and-container-scan.yml
 
   deploy-infrastructure:

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -8,18 +8,64 @@ on:
         value: ${{ jobs.secrets-scan.outputs.result }}
 
 jobs:
-  # 🚧 REPLACE THIS ENTIRE 'jobs:' SECTION WITH WORKSHOP CONTENT! 🚧
-  # Copy from: workshop/secrets_scan/{tool}/workflow.yml
-
   secrets-scan:
-    name: "🚧 Secrets Scan - Workshop Placeholder"
+    name: Secrets Scan with Gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     outputs:
-      result: ${{ steps.placeholder.outputs.result }}
+      result: ${{ steps.scan-result.outputs.result }}
     steps:
-      - name: Workshop Placeholder
-        id: placeholder
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks secrets scanner
+        id: scan-tool
         run: |
-          echo "🚧 Replace this job with content from workshop/secrets_scan/{tool}/workflow.yml!"
-          echo "This will implement: Secrets detection with your chosen tool"
-          echo "result=workshop-placeholder" >> "$GITHUB_OUTPUT"
+          wget -q -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp/
+          sudo mv /tmp/gitleaks /usr/local/bin/
+
+          gitleaks detect --source . --no-git --verbose --report-format sarif --report-path gitleaks.sarif --exit-code 1
+
+      - name: Summarize findings
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        run: |
+          SARIF=gitleaks.sarif
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Gitleaks finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+      - name: Set scan result
+        id: scan-result
+        if: always()
+        run: |
+          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "✅ Secrets scan passed - no secrets detected"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "❌ Secrets scan failed - secrets detected in repository"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
+            exit 1
+          fi

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -8,64 +8,18 @@ on:
         value: ${{ jobs.secrets-scan.outputs.result }}
 
 jobs:
+  # 🚧 REPLACE THIS ENTIRE 'jobs:' SECTION WITH WORKSHOP CONTENT! 🚧
+  # Copy from: workshop/secrets_scan/{tool}/workflow.yml
+
   secrets-scan:
-    name: Secrets Scan with Gitleaks
+    name: "🚧 Secrets Scan - Workshop Placeholder"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     outputs:
-      result: ${{ steps.scan-result.outputs.result }}
+      result: ${{ steps.placeholder.outputs.result }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks secrets scanner
-        id: scan-tool
+      - name: Workshop Placeholder
+        id: placeholder
         run: |
-          wget -q -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
-          tar -xzf /tmp/gitleaks.tar.gz -C /tmp/
-          sudo mv /tmp/gitleaks /usr/local/bin/
-
-          gitleaks detect --source . --no-git --verbose --report-format sarif --report-path gitleaks.sarif --exit-code 1
-
-      - name: Summarize findings
-        if: always() && hashFiles('gitleaks.sarif') != ''
-        run: |
-          SARIF=gitleaks.sarif
-          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
-          if [ "${COUNT:-0}" -eq 0 ]; then
-            echo "✅ No security alerts"
-          else
-            echo "❌ Found $COUNT Gitleaks finding(s):"
-            jq -r '.runs[].results[] |
-              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
-              "$SARIF"
-          fi
-
-      - name: Upload SARIF to GitHub Code Scanning
-        if: always() && hashFiles('gitleaks.sarif') != ''
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
-        with:
-          sarif_file: gitleaks.sarif
-          category: gitleaks
-
-      - name: Set scan result
-        id: scan-result
-        if: always()
-        run: |
-          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
-            echo "result=success" >> "$GITHUB_OUTPUT"
-            echo "✅ Secrets scan passed - no secrets detected"
-          else
-            echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "❌ Secrets scan failed - secrets detected in repository"
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
-            else
-              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
-            fi
-            exit 1
-          fi
+          echo "🚧 Replace this job with content from workshop/secrets_scan/{tool}/workflow.yml!"
+          echo "This will implement: Secrets detection with your chosen tool"
+          echo "result=workshop-placeholder" >> "$GITHUB_OUTPUT"

--- a/workshop/secrets_scan/gitleaks/workflow.yml
+++ b/workshop/secrets_scan/gitleaks/workflow.yml
@@ -9,14 +9,18 @@
 # 1. Copy this entire job definition into .github/workflows/secrets-scan.yml
 # 2. Replace the current jobs: definition with this one
 # 3. The job will scan the current filesystem for secrets (not git history)
-# 4. The scan will fail if any secrets are found
-# 5. For production use, consider enabling git history scan (see OPTION 1 below)
+# 4. Results will be uploaded to GitHub Advanced Security (SARIF format)
+# 5. The scan will fail if any secrets are found
+# 6. For production use, consider enabling git history scan (see OPTION 1 below)
 # =============================================================================
 
 jobs:
   secrets-scan:
     name: Secrets Scan with Gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     outputs:
       result: ${{ steps.scan-result.outputs.result }}
     steps:
@@ -29,17 +33,38 @@ jobs:
         id: scan-tool
         run: |
           # Install Gitleaks
-          wget -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
+          wget -q -O /tmp/gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp/
           sudo mv /tmp/gitleaks /usr/local/bin/
 
           # OPTION 1: Scan entire git history + current filesystem (recommended for production CI)
           # NOTE: This option may require cleaning git history if secrets are found in past commits
-          # gitleaks detect --source . --verbose --exit-code 1
+          # gitleaks detect --source . --verbose --report-format sarif --report-path gitleaks.sarif --exit-code 1
 
           # OPTION 2: Scan only current filesystem without git history (WORKSHOP DEFAULT)
           # This option is used for the workshop as it focuses on current code without requiring git history cleanup
-          gitleaks detect --source . --no-git --verbose --exit-code 1
+          gitleaks detect --source . --no-git --verbose --report-format sarif --report-path gitleaks.sarif --exit-code 1
+
+      - name: Summarize findings
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        run: |
+          SARIF=gitleaks.sarif
+          COUNT=$(jq '[.runs[].results[]] | length' "$SARIF")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT Gitleaks finding(s):"
+            jq -r '.runs[].results[] |
+              "  - \(.ruleId) | \(.message.text)\n      \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // 1)"' \
+              "$SARIF"
+          fi
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always() && hashFiles('gitleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
 
       - name: Set scan result
         id: scan-result
@@ -51,5 +76,10 @@ jobs:
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ Secrets scan failed - secrets detected in repository"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Gitleaks now generates SARIF (\`--report-format sarif\`) and uploads it to GitHub Code Scanning under category \`gitleaks\` so detected secrets appear as inline \`github-advanced-security\` bot comments on the PR diff and as alerts in the Security tab.
- Adds the standard \`Summarize findings\` step matching the cross-tool pattern (Trivy, Checkov, CodeQL, Dependency-Check, etc.).
- Grants \`security-events: write\` to the job and to the orchestrator's \`secrets-scan\` caller so the reusable workflow can upload SARIF.
- Silences the \`wget\` install progress noise the workshop README warns about.
- Temporarily replaces the \`secrets-scan\` placeholder with the Gitleaks job to verify the integration on this PR; will be reverted before merge.

## Test plan
- [ ] Workflow \`Pipeline Orchestrator / secrets-scan\` runs and Gitleaks fails with the planted bait at \`code/src/simple-app.js:4-5\`.
- [ ] \`Summarize findings\` step prints \`❌ Found N Gitleaks finding(s):\` with rule + path:line.
- [ ] \`Upload SARIF to GitHub Code Scanning\` step succeeds.
- [ ] PR shows inline \`github-advanced-security\` comments on \`code/src/simple-app.js:4-5\`.
- [ ] \`Checks\` tab shows \`Code scanning / gitleaks\` entry.
- [ ] \`Security → Code scanning\` lists the alerts under the \`gitleaks\` category.