### PR TITLE
Improve findings surfacing across workshop modules

### DIFF
--- a/workshop/ai_review/gemini/workflow.yml
+++ b/workshop/ai_review/gemini/workflow.yml
@@ -136,6 +136,22 @@ jobs:
 
           echo "✅ Gemini returned $(jq '.findings | length' findings.json) finding(s)"
 
+      - name: Summarize findings
+        if: always() && hashFiles('findings.json') != ''
+        run: |
+          REPORT=findings.json
+          COUNT=$(jq '.findings | length' "$REPORT")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Found $COUNT AI review finding(s):"
+            jq -r '.findings[] | "  - \(.id) | \(.severity) | \(.title)\n      \(.location)"' "$REPORT"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo ""
+              echo "🔍 Full report: see the '🤖 AI Security Review' comment on the PR conversation."
+            fi
+          fi
+
       - name: Post review comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0

--- a/workshop/code_scan/README.md
+++ b/workshop/code_scan/README.md
@@ -47,7 +47,7 @@ Vulnerabilities in your code or your dependencies are the path attackers take to
 | [**CodeQL**](https://github.com/github/codeql) | SAST | GitHub's semantic code analysis engine for deep security analysis | [Action](https://github.com/github/codeql-action) · [Docs](https://codeql.github.com/docs/) |
 | [**Semgrep**](https://github.com/semgrep/semgrep) | SAST | Fast pattern-based scanner with extensive rule sets | [Docs](https://semgrep.dev/docs/) · [Community rules](https://semgrep.dev/explore) |
 | [**osv-scanner**](https://github.com/google/osv-scanner) | SCA | Lockfile-based vulnerability scanner backed by [OSV.dev](https://osv.dev/) | [Action](https://github.com/google/osv-scanner-action) · [Docs](https://google.github.io/osv-scanner/) |
-| [**OWASP Dependency Check**](https://github.com/dependency-check/DependencyCheck) | SCA | OWASP SCA tool for known vulnerabilities in dependencies | Requires `NVD_API_KEY` ([request one](https://nvd.nist.gov/developers/request-an-api-key)) — without it, the scan may return 0 findings |
+| [**OWASP Dependency Check**](https://github.com/dependency-check/DependencyCheck) | SCA | OWASP SCA tool for known vulnerabilities in dependencies | The workshop action uses bundled NVD data (`--noupdate`), so no API key is required to run the demo. For production you'd typically install dependency-check directly and pass `--nvdApiKey` to refresh the feed. |
 
 > **Note**: Different ecosystems have specialized SAST tools (e.g., ESLint with security plugins for JavaScript, Bandit for Python, Brakeman for Ruby on Rails) that can provide more targeted analysis alongside general-purpose scanners.
 

--- a/workshop/code_scan/sast/codeQL/workflow.yml
+++ b/workshop/code_scan/sast/codeQL/workflow.yml
@@ -87,6 +87,11 @@ jobs:
           if [ "${COUNT:-0}" -gt 0 ]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ CodeQL found $COUNT security alert(s)"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           else
             echo "result=success" >> "$GITHUB_OUTPUT"

--- a/workshop/code_scan/sca/dependency_check/workflow.yml
+++ b/workshop/code_scan/sca/dependency_check/workflow.yml
@@ -31,9 +31,7 @@ jobs:
           project: 'code'
           path: './code'
           format: 'ALL'
-          args: >
-            --failOnCVSS 7
-            --enableRetired
+          others: '--failOnCVSS=7'
 
       - name: Summarize findings
         if: always() && hashFiles('reports/dependency-check-report.sarif') != ''

--- a/workshop/code_scan/sca/dependency_check/workflow.yml
+++ b/workshop/code_scan/sca/dependency_check/workflow.yml
@@ -64,6 +64,11 @@ jobs:
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ Code scan failed — vulnerabilities detected"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           fi
 

--- a/workshop/code_scan/sca/osv-scanner/workflow.yml
+++ b/workshop/code_scan/sca/osv-scanner/workflow.yml
@@ -69,5 +69,10 @@ jobs:
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ Code scan failed - vulnerabilities detected"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           fi

--- a/workshop/container_scan/grype/workflow.yml
+++ b/workshop/container_scan/grype/workflow.yml
@@ -98,8 +98,11 @@ jobs:
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "❌ Container scan failed - vulnerabilities at or above the configured severity threshold detected"
-            echo "🔍 View security findings for this PR:"
-            echo "https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.pull_request.number }}+is%3Aopen"
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning?query=pr%3A${{ github.event.number }}+is%3Aopen"
+            else
+              echo "🔍 View findings: https://github.com/${{ github.repository }}/security/code-scanning"
+            fi
             exit 1
           fi
 

--- a/workshop/pipeline_scan/claws/workflow.yml
+++ b/workshop/pipeline_scan/claws/workflow.yml
@@ -75,6 +75,16 @@ jobs:
           # Execute the security analysis
           analyze -f stdout -c /tmp/claws-config.yml "${flags[@]}"
 
+      - name: Summarize findings
+        if: always()
+        run: |
+          if [ "${{ steps.scan-tool.outcome }}" == "success" ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Claws detected workflow security issues."
+            echo "🔍 View findings: see the 'Run Claws pipeline scanner' step output above (Claws prints findings to stdout)."
+          fi
+
       - name: Set scan result
         id: scan-result
         if: always()

--- a/workshop/pipeline_scan/extra/prowler/workflow.yml
+++ b/workshop/pipeline_scan/extra/prowler/workflow.yml
@@ -84,6 +84,16 @@ jobs:
           path: output/*.html
           retention-days: 1
 
+      - name: Summarize findings
+        if: always()
+        run: |
+          if [ "${{ steps.prowler.outcome }}" == "success" ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Prowler detected repository security issues."
+            echo "🔍 View findings: download the 'prowler-html-report' artifact from this run (Artifacts section at the top of the run page)."
+          fi
+
       - name: Set scan result
         id: scan-result
         if: always()

--- a/workshop/runtime_infra_scan/prowler/workflow.yml
+++ b/workshop/runtime_infra_scan/prowler/workflow.yml
@@ -66,6 +66,16 @@ jobs:
           path: output/*.html
           retention-days: 3
 
+      - name: Summarize findings
+        if: always()
+        run: |
+          if [ "${{ steps.prowler.outcome }}" == "success" ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Prowler detected runtime infrastructure security issues."
+            echo "🔍 View findings: download the 'prowler-html-report' artifact from this run (Artifacts section at the top of the run page)."
+          fi
+
       - name: Set scan result
         id: scan-result
         if: always()

--- a/workshop/runtime_infra_scan/steampipe/workflow.yml
+++ b/workshop/runtime_infra_scan/steampipe/workflow.yml
@@ -77,6 +77,16 @@ jobs:
           path: aws_compliance.benchmark.cis_v150.*.html
           retention-days: 3
 
+      - name: Summarize findings
+        if: always()
+        run: |
+          if [ "${{ steps.powerpipe.outcome }}" == "success" ]; then
+            echo "✅ No security alerts"
+          else
+            echo "❌ Powerpipe detected runtime infrastructure compliance issues."
+            echo "🔍 View findings: download the 'powerpipe-html-report' artifact from this run (Artifacts section at the top of the run page)."
+          fi
+
       - name: Set scan result
         id: scan-result
         if: always()

--- a/workshop/secrets_scan/README.md
+++ b/workshop/secrets_scan/README.md
@@ -110,17 +110,17 @@ By the end of this module, you will:
 <details>
 <summary><b>TruffleHog</b> — <code>Detector Type: AWS</code> at <code>code/src/simple-app.js:4</code></summary>
 
-**What TruffleHog flagged**: 1 unverified result on the `AKIA…` access-key literal. The job log prints a clean block:
+**What TruffleHog flagged**: 1 unverified result on the `AKIA…` access-key literal. Look in the **`Summarize findings`** step:
 
 ```
-Found unverified result 🐷🔑❓
-Detector Type: AWS
-Raw result: AKIA…
-File: code/src/simple-app.js
-Line: 4
+❌ Found 1 TruffleHog finding(s):
+  - AWS | verified=false
+      code/src/simple-app.js:4
 ```
 
 **Why the snippet uses `--results=verified,unknown,unverified`**: the workshop's AKIA is not a real AWS key, so TruffleHog can't validate it against AWS. Under the default `verified`-only filter the build would silently pass — the extra flags are what make the bait fire.
+
+**Why we run with `--json`**: the snippet pipes JSON output into a follow-up `Summarize findings` step (same shape as the other workshop modules). The default `verified=false` field tells you the secret matched a pattern but couldn't be validated against the live provider.
 
 **Fix** — move the hardcoded credentials to environment variables:
 

--- a/workshop/secrets_scan/trufflehog/workflow.yml
+++ b/workshop/secrets_scan/trufflehog/workflow.yml
@@ -31,9 +31,27 @@ jobs:
           # Install TruffleHog
           curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
+          # Use --json so the next step can produce a uniform "Summarize findings"
+          # report (same shape as the other workshop modules).
           # Include `unverified` so detected-but-unverifiable secrets still fail the build
           # (the workshop's didactic AKIA is invalid and would otherwise be silently dropped).
-          trufflehog filesystem . --results=verified,unknown,unverified --fail
+          trufflehog filesystem . --results=verified,unknown,unverified --json > trufflehog.json
+
+          if [ -s trufflehog.json ]; then
+            exit 1
+          fi
+
+      - name: Summarize findings
+        if: always() && hashFiles('trufflehog.json') != ''
+        run: |
+          REPORT=trufflehog.json
+          if [ ! -s "$REPORT" ]; then
+            echo "✅ No security alerts"
+          else
+            COUNT=$(jq -s 'length' "$REPORT")
+            echo "❌ Found $COUNT TruffleHog finding(s):"
+            jq -r '"  - \(.DetectorName) | verified=\(.Verified)\n      \(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line // 1)"' "$REPORT"
+          fi
 
       - name: Set scan result
         id: scan-result


### PR DESCRIPTION
## Summary
Three related improvements to make workshop findings easier to read and act on, applied uniformly across modules.

### 1. Uniform `Summarize findings` step in every module
Every module's snippet now includes a `Summarize findings` step so attendees always know where to look in the run log, regardless of which tool they picked. Two patterns depending on what the tool produces:

- **Structured output** (TruffleHog, Gemini AI review) → parse the JSON report and print a per-finding summary (rule/severity/location).
- **HTML artifacts or plain stdout** (Claws, Prowler ×2, Steampipe) → uniform pointer to the artifact name or the upstream step output.

For TruffleHog this required switching from `--fail` to `--json > trufflehog.json` + a manual `exit 1`, so the new Summarize step can read the JSON. The `secrets_scan/README.md` spoiler is updated accordingly.

### 2. Make Dependency Check actually fail on findings
`workshop/code_scan/sca/dependency_check/workflow.yml` used `args:` to pass `--failOnCVSS 7 --enableRetired`. The action's [`action.yml`](https://github.com/dependency-check/Dependency-Check_Action/blob/75ba02d6183445fe0761d26e836bde58b1560600/action.yml) only exposes a single `others` input — GitHub Actions silently drops unknown inputs, so none of those flags reached the scanner and the job exited 0 even with high-CVSS findings.

Fix: switch to `others: '--failOnCVSS=7'` (equals syntax required because the action passes `others` as ONE quoted argument; spaces would break parsing). Tradeoff: the action's design only allows one additional flag, so `--enableRetired` is dropped.

`code_scan/README.md` also dropped a misleading note claiming `NVD_API_KEY` is required: the action hardcodes `--noupdate`, so the bundled NVD data is what's used and the API key is never read.

### 3. Code Scanning link in `Set scan result`
Match the gitleaks/checkov/trivy/semgrep pattern: when a SARIF-uploading job fails, print a link to the GitHub Code Scanning view filtered by the current PR (and a fallback to the unfiltered view on push).

Modules updated for parity: `dependency_check`, `osv-scanner`, `codeQL`, `grype` (the latter already had the PR-only variant; added the non-PR fallback and standardized on `github.event.number`).

## Test plan
- [ ] Run each module's snippet against the workshop's bait code/dependencies; verify the `Summarize findings` step renders the expected format.
- [ ] Dependency Check fails the build when `code/package.json` carries `axios 1.6.0` (CVSS ≥ 7).
- [ ] Failing modules print a clickable link to Security ▸ Code scanning, scoped to the PR.